### PR TITLE
feat: 사용자 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/dku/emptybear/common/config/SecurityConfig.java
+++ b/src/main/java/com/dku/emptybear/common/config/SecurityConfig.java
@@ -1,12 +1,37 @@
-package com.emptybear.common.config;
+package com.dku.emptybear.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/",
+                                "/login",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/api-docs/**",
+                                "/webjars/**",
+                                "/api/auth/signup"
+                        ).permitAll()
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/dku/emptybear/common/config/SecurityConfig.java
+++ b/src/main/java/com/dku/emptybear/common/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.emptybear.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/dku/emptybear/common/config/SwaggerConfig.java
+++ b/src/main/java/com/dku/emptybear/common/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.dku.emptybear.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI emptyBearOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Empty Bear API")
+                        .description("빈 강의실 추천 서비스 API 문서")
+                        .version("v1.0.0"));
+    }
+}

--- a/src/main/java/com/dku/emptybear/common/error/ErrorResponse.java
+++ b/src/main/java/com/dku/emptybear/common/error/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.emptybear.common.error;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private int status;
+    private String message;
+}

--- a/src/main/java/com/dku/emptybear/common/error/ErrorResponse.java
+++ b/src/main/java/com/dku/emptybear/common/error/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.emptybear.common.error;
+package com.dku.emptybear.common.error;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/dku/emptybear/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/dku/emptybear/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,59 @@
+package com.emptybear.common.error;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // @Valid 검증 실패 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(
+            MethodArgumentNotValidException e
+    ) {
+        String message = e.getBindingResult()
+                .getFieldErrors()
+                .get(0)
+                .getDefaultMessage();
+
+        ErrorResponse response = ErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message(message)
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(response);
+    }
+
+    // IllegalArgumentException 처리
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
+            IllegalArgumentException e
+    ) {
+        ErrorResponse response = ErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message(e.getMessage())
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(response);
+    }
+
+    // 예상하지 못한 서버 에러 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        ErrorResponse response = ErrorResponse.builder()
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .message("서버 내부 오류가 발생했습니다.")
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(response);
+    }
+}

--- a/src/main/java/com/dku/emptybear/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/dku/emptybear/common/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.dku.emptybear.common.error;
 
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -14,14 +15,9 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleValidationException(
             MethodArgumentNotValidException e
     ) {
-        String message = e.getBindingResult()
-                .getFieldErrors()
-                .get(0)
-                .getDefaultMessage();
-
         ErrorResponse response = ErrorResponse.builder()
                 .status(HttpStatus.BAD_REQUEST.value())
-                .message(message)
+                .message(getValidationMessage(e))
                 .build();
 
         return ResponseEntity
@@ -55,5 +51,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(response);
+    }
+
+    private String getValidationMessage(MethodArgumentNotValidException e) {
+        return e.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .findFirst()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse("잘못된 요청입니다.");
     }
 }

--- a/src/main/java/com/dku/emptybear/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/dku/emptybear/common/error/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.emptybear.common.error;
+package com.dku.emptybear.common.error;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
@@ -1,8 +1,8 @@
-package com.emptybear.domain.auth.controller;
+package com.dku.emptybear.domain.auth.controller;
 
-import com.emptybear.domain.auth.dto.request.SignupRequestDto;
-import com.emptybear.domain.auth.dto.response.SignupResponseDto;
-import com.emptybear.domain.auth.service.AuthService;
+import com.dku.emptybear.domain.auth.dto.request.SignupRequestDto;
+import com.dku.emptybear.domain.auth.dto.response.SignupResponseDto;
+import com.dku.emptybear.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
@@ -1,0 +1,23 @@
+package com.emptybear.domain.auth.controller;
+
+import com.emptybear.domain.auth.dto.request.SignupRequestDto;
+import com.emptybear.domain.auth.dto.response.SignupResponseDto;
+import com.emptybear.domain.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED)
+    public SignupResponseDto signup(@Valid @RequestBody SignupRequestDto request) {
+        return authService.signup(request);
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
@@ -3,11 +3,14 @@ package com.dku.emptybear.domain.auth.controller;
 import com.dku.emptybear.domain.auth.dto.request.SignupRequestDto;
 import com.dku.emptybear.domain.auth.dto.response.SignupResponseDto;
 import com.dku.emptybear.domain.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Auth", description = "인증 관련 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -15,6 +18,10 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(
+            summary = "회원가입",
+            description = "로그인 아이디, 비밀번호, 닉네임, 학번, 학과를 입력받아 새로운 사용자를 등록합니다."
+    )
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
     public SignupResponseDto signup(@Valid @RequestBody SignupRequestDto request) {

--- a/src/main/java/com/dku/emptybear/domain/auth/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/dto/request/SignupRequestDto.java
@@ -1,4 +1,4 @@
-package com.emptybear.domain.auth.dto.request;
+package com.dku.emptybear.domain.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;

--- a/src/main/java/com/dku/emptybear/domain/auth/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/dto/request/SignupRequestDto.java
@@ -1,0 +1,23 @@
+package com.emptybear.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SignupRequestDto {
+
+    @NotBlank(message = "로그인 아이디는 필수입니다.")
+    private String loginId;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    private String nickname;
+
+    @NotBlank(message = "학번은 필수입니다.")
+    private String studentNumber;
+
+    @NotBlank(message = "학과는 필수입니다.")
+    private String department;
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/dto/request/SignupRequestDto.java
@@ -1,23 +1,29 @@
 package com.dku.emptybear.domain.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class SignupRequestDto {
 
+    @Schema(description = "사용자 로그인 아이디", example = "emptybear01")
     @NotBlank(message = "로그인 아이디는 필수입니다.")
     private String loginId;
 
+    @Schema(description = "사용자 비밀번호", example = "qwer1234!")
     @NotBlank(message = "비밀번호는 필수입니다.")
     private String password;
 
+    @Schema(description = "사용자 닉네임", example = "비었곰")
     @NotBlank(message = "닉네임은 필수입니다.")
     private String nickname;
 
+    @Schema(description = "사용자 학번", example = "32231234")
     @NotBlank(message = "학번은 필수입니다.")
     private String studentNumber;
 
+    @Schema(description = "사용자 학과", example = "소프트웨어학과")
     @NotBlank(message = "학과는 필수입니다.")
     private String department;
 }

--- a/src/main/java/com/dku/emptybear/domain/auth/dto/response/SignupResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/dto/response/SignupResponseDto.java
@@ -1,4 +1,4 @@
-package com.emptybear.domain.auth.dto.response;
+package com.dku.emptybear.domain.auth.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/dku/emptybear/domain/auth/dto/response/SignupResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/dto/response/SignupResponseDto.java
@@ -1,0 +1,19 @@
+package com.emptybear.domain.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SignupResponseDto {
+
+    private UserInfoDto user;
+    private String message;
+
+    @Getter
+    @Builder
+    public static class UserInfoDto {
+        private Long userId;
+        private String loginId;
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/dto/response/SignupResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/dto/response/SignupResponseDto.java
@@ -1,5 +1,6 @@
 package com.dku.emptybear.domain.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,13 +8,20 @@ import lombok.Getter;
 @Builder
 public class SignupResponseDto {
 
+    @Schema(description = "생성된 사용자 정보")
     private UserInfoDto user;
+
+    @Schema(description = "회원가입 성공 메시지", example = "회원가입에 성공했습니다.")
     private String message;
 
     @Getter
     @Builder
     public static class UserInfoDto {
+
+        @Schema(description = "생성된 사용자 고유 ID", example = "1")
         private Long userId;
+
+        @Schema(description = "생성된 사용자 로그인 아이디", example = "emptybear01")
         private String loginId;
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
@@ -1,0 +1,58 @@
+package com.emptybear.domain.auth.service;
+
+import com.emptybear.domain.auth.dto.request.SignupRequestDto;
+import com.emptybear.domain.auth.dto.response.SignupResponseDto;
+import com.emptybear.domain.user.entity.User;
+import com.emptybear.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public SignupResponseDto signup(SignupRequestDto request) {
+        validateDuplicate(request);
+
+        User user = User.builder()
+                .loginId(request.getLoginId())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .nickname(request.getNickname())
+                .studentNumber(request.getStudentNumber())
+                .department(request.getDepartment())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        User savedUser = userRepository.save(user);
+
+        return SignupResponseDto.builder()
+                .user(SignupResponseDto.UserInfoDto.builder()
+                        .userId(savedUser.getUserId())
+                        .loginId(savedUser.getLoginId())
+                        .build())
+                .message("회원가입에 성공했습니다.")
+                .build();
+    }
+
+    private void validateDuplicate(SignupRequestDto request) {
+        if (userRepository.existsByLoginId(request.getLoginId())) {
+            throw new IllegalArgumentException("이미 사용 중인 로그인 아이디입니다.");
+        }
+
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        }
+
+        if (userRepository.existsByStudentNumber(request.getStudentNumber())) {
+            throw new IllegalArgumentException("이미 등록된 학번입니다.");
+        }
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
@@ -28,7 +28,6 @@ public class AuthService {
                 .nickname(request.getNickname())
                 .studentNumber(request.getStudentNumber())
                 .department(request.getDepartment())
-                .createdAt(LocalDateTime.now())
                 .build();
 
         User savedUser = userRepository.save(user);

--- a/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
@@ -1,9 +1,9 @@
-package com.emptybear.domain.auth.service;
+package com.dku.emptybear.domain.auth.service;
 
-import com.emptybear.domain.auth.dto.request.SignupRequestDto;
-import com.emptybear.domain.auth.dto.response.SignupResponseDto;
-import com.emptybear.domain.user.entity.User;
-import com.emptybear.domain.user.repository.UserRepository;
+import com.dku.emptybear.domain.auth.dto.request.SignupRequestDto;
+import com.dku.emptybear.domain.auth.dto.response.SignupResponseDto;
+import com.dku.emptybear.domain.user.entity.User;
+import com.dku.emptybear.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/dku/emptybear/domain/user/entity/User.java
+++ b/src/main/java/com/dku/emptybear/domain/user/entity/User.java
@@ -1,4 +1,4 @@
-package com.emptybear.domain.user.entity;
+package com.dku.emptybear.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/dku/emptybear/domain/user/entity/User.java
+++ b/src/main/java/com/dku/emptybear/domain/user/entity/User.java
@@ -1,0 +1,47 @@
+package com.emptybear.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(name = "login_id", nullable = false, length = 50)
+    private String loginId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String nickname;
+
+    @Column(name = "student_number", nullable = false, length = 20)
+    private String studentNumber;
+
+    @Column(nullable = false, length = 100)
+    private String department;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public User(String loginId, String password, String nickname, String studentNumber, String department) {
+        this.loginId = loginId;
+        this.password = password;
+        this.nickname = nickname;
+        this.studentNumber = studentNumber;
+        this.department = department;
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/user/entity/User.java
+++ b/src/main/java/com/dku/emptybear/domain/user/entity/User.java
@@ -16,24 +16,25 @@ public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long userId;
 
-    @Column(name = "login_id", nullable = false, length = 50)
+    @Column(name = "login_id", nullable = false, length = 50, unique = true)
     private String loginId;
 
-    @Column(nullable = false)
+    @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(nullable = false, length = 50)
+    @Column(name = "nickname", nullable = false, length = 50, unique = true)
     private String nickname;
 
-    @Column(name = "student_number", nullable = false, length = 20)
+    @Column(name = "student_number", nullable = false, length = 20, unique = true)
     private String studentNumber;
 
-    @Column(nullable = false, length = 100)
+    @Column(name = "department", nullable = false, length = 100)
     private String department;
 
-    @Column(nullable = false, updatable = false)
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Builder

--- a/src/main/java/com/dku/emptybear/domain/user/entity/User.java
+++ b/src/main/java/com/dku/emptybear/domain/user/entity/User.java
@@ -44,4 +44,9 @@ public class User {
         this.studentNumber = studentNumber;
         this.department = department;
     }
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/dku/emptybear/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/user/repository/UserRepository.java
@@ -1,6 +1,6 @@
-package com.emptybear.domain.user.repository;
+package com.dku.emptybear.domain.user.repository;
 
-import com.emptybear.domain.user.entity.User;
+import com.dku.emptybear.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {

--- a/src/main/java/com/dku/emptybear/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.emptybear.domain.user.repository;
+
+import com.emptybear.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByLoginId(String loginId);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByStudentNumber(String studentNumber);
+}


### PR DESCRIPTION
## 📝 개요 (Overview)
- 사용자 회원가입 API를 구현했습니다.
- 로그인 아이디, 비밀번호, 닉네임, 학번, 학과 정보를 입력받아 신규 사용자를 등록할 수 있도록 구현했습니다.
- 회원가입 요청 및 응답 DTO, 인증 컨트롤러, 인증 서비스, 사용자 Repository를 추가했습니다.

## 📌 이슈 번호 작성 (Related Issue)
- Closes #3 

## 🤔 작업 배경 및 목적 (Why)
- 서비스 이용을 위해 사용자 계정 생성 기능이 필요했습니다.
- 회원가입 시 사용자 정보를 DB에 저장하고, 이후 로그인 및 JWT 인증 기능과 연결할 수 있는 기반을 마련하기 위해 구현했습니다.
- 비밀번호는 평문으로 저장하지 않고 `PasswordEncoder`를 통해 암호화하여 저장하도록 처리했습니다.

## 🏷️ PR 유형 (Type of PR)
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 사용자 UI 디자인 변경
- [ ] ♻️ 코드 리팩토링
- [ ] 📝 문서 수정 (Wiki, README 등)
- [ ] ✅ 테스트 추가 및 리팩토링
- [ ] 📁 파일 혹은 폴더 구조 수정 및 삭제

## 🛠️ 주요 변경 사항 (What)
- `/api/auth/signup` 회원가입 API 추가
- `SignupRequestDto` 추가
  - `loginId`
  - `password`
  - `nickname`
  - `studentNumber`
  - `department`
- `SignupResponseDto` 추가
  - 생성된 사용자 ID
  - 로그인 아이디
  - 회원가입 성공 메시지
- `AuthController` 추가
  - 회원가입 요청 처리
- `AuthService` 추가
  - 로그인 아이디, 닉네임, 학번 중복 검사
  - 비밀번호 암호화
  - 사용자 저장 처리
- `UserRepository`에 중복 검사용 메서드 추가
  - `existsByLoginId`
  - `existsByNickname`
  - `existsByStudentNumber`
- `PasswordEncoder` 설정 추가
- 회원가입 API 확인을 위한 Swagger 설정 및 문서화 적용

## 📸 스크린 샷 (Optional)

## ✅ 체크리스트
- [x] 불필요한 주석/코드 및 디버깅용 로그 제거
- [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 단위 테스트 등)
- [x] 시뮬레이터 또는 실제 기기에서 정상 동작하는지 확인
- [x] 커밋 메시지 컨벤션을 준수 (*Commit message convention 참고)
- [ ] 관련 이슈를 닫는 커밋 메시지 사용 (Closes #)
- [x] PR 제목과 내용 명확히 작성

## 💬 리뷰 포인트 (To Reviewers)
- 회원가입 요청/응답 DTO 구조가 API 명세와 일치하는지 확인 부탁드립니다.
- 로그인 아이디, 닉네임, 학번 중복 검사 로직이 적절한지 확인 부탁드립니다.
- 비밀번호 암호화 방식과 `PasswordEncoder` 설정 위치가 적절한지 확인 부탁드립니다.
- 추후 JWT 로그인 기능과 연결하기 위해 현재 `auth` 도메인에 회원가입 API를 배치한 구조가 적절한지 확인 부탁드립니다.