### PR TITLE
feat: 로그인, 로그아웃, 토큰 재발급 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dku/emptybear/common/config/SecurityConfig.java
+++ b/src/main/java/com/dku/emptybear/common/config/SecurityConfig.java
@@ -26,7 +26,9 @@ public class SecurityConfig {
                                 "/api-docs/**",
                                 "/webjars/**",
                                 "/api/auth/signup",
-                                "/api/auth/login"
+                                "/api/auth/login",
+                                "/api/auth/logout",
+                                "/api/auth/reissue"
                         ).permitAll()
                         .anyRequest().permitAll()
                 );

--- a/src/main/java/com/dku/emptybear/common/config/SecurityConfig.java
+++ b/src/main/java/com/dku/emptybear/common/config/SecurityConfig.java
@@ -25,7 +25,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/api-docs/**",
                                 "/webjars/**",
-                                "/api/auth/signup"
+                                "/api/auth/signup",
+                                "/api/auth/login"
                         ).permitAll()
                         .anyRequest().permitAll()
                 );

--- a/src/main/java/com/dku/emptybear/common/config/SwaggerConfig.java
+++ b/src/main/java/com/dku/emptybear/common/config/SwaggerConfig.java
@@ -1,7 +1,9 @@
 package com.dku.emptybear.common.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,6 +13,14 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI emptyBearOpenAPI() {
         return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                )
                 .info(new Info()
                         .title("Empty Bear API")
                         .description("빈 강의실 추천 서비스 API 문서")

--- a/src/main/java/com/dku/emptybear/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/dku/emptybear/common/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.MissingRequestHeaderException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -60,5 +61,19 @@ public class GlobalExceptionHandler {
                 .findFirst()
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .orElse("잘못된 요청입니다.");
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(
+            MissingRequestHeaderException e
+    ) {
+        ErrorResponse response = ErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message("유효하지 않은 토큰입니다.")
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(response);
     }
 }

--- a/src/main/java/com/dku/emptybear/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/dku/emptybear/common/error/GlobalExceptionHandler.java
@@ -6,7 +6,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.bind.MissingRequestHeaderException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -61,19 +60,5 @@ public class GlobalExceptionHandler {
                 .findFirst()
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .orElse("잘못된 요청입니다.");
-    }
-
-    @ExceptionHandler(MissingRequestHeaderException.class)
-    public ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(
-            MissingRequestHeaderException e
-    ) {
-        ErrorResponse response = ErrorResponse.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
-                .message("유효하지 않은 토큰입니다.")
-                .build();
-
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(response);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
@@ -8,9 +8,8 @@ import com.dku.emptybear.domain.auth.dto.response.SignupResponseDto;
 import com.dku.emptybear.domain.auth.dto.response.AuthMessageResponseDto;
 import com.dku.emptybear.domain.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -47,13 +46,9 @@ public class AuthController {
             summary = "로그아웃",
             description = "로그인된 사용자의 로그아웃을 처리하고, 리프레시 토큰을 무효화합니다."
     )
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/logout")
     public AuthMessageResponseDto logout(
-            @Parameter(
-                description = "액세스 토큰",
-                example = "Bearer access-token-example",
-                in = ParameterIn.HEADER
-            )
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @Valid @RequestBody LogoutRequestDto request
     ) {

--- a/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
@@ -3,9 +3,11 @@ package com.dku.emptybear.domain.auth.controller;
 import com.dku.emptybear.domain.auth.dto.request.LoginRequestDto;
 import com.dku.emptybear.domain.auth.dto.request.SignupRequestDto;
 import com.dku.emptybear.domain.auth.dto.request.LogoutRequestDto;
+import com.dku.emptybear.domain.auth.dto.request.ReissueRequestDto;
 import com.dku.emptybear.domain.auth.dto.response.LoginResponseDto;
 import com.dku.emptybear.domain.auth.dto.response.SignupResponseDto;
 import com.dku.emptybear.domain.auth.dto.response.AuthMessageResponseDto;
+import com.dku.emptybear.domain.auth.dto.response.ReissueResponseDto;
 import com.dku.emptybear.domain.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -53,5 +55,16 @@ public class AuthController {
             @Valid @RequestBody LogoutRequestDto request
     ) {
         return authService.logout(authorizationHeader, request);
+    }
+
+    @Operation(
+            summary = "액세스 토큰 재발급",
+            description = "리프레시 토큰을 검증한 뒤 새로운 액세스 토큰을 발급합니다."
+    )
+    @PostMapping("/reissue")
+    public ReissueResponseDto reissue(
+            @Valid @RequestBody ReissueRequestDto request
+    ) {
+        return authService.reissue(request);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
@@ -2,11 +2,15 @@ package com.dku.emptybear.domain.auth.controller;
 
 import com.dku.emptybear.domain.auth.dto.request.LoginRequestDto;
 import com.dku.emptybear.domain.auth.dto.request.SignupRequestDto;
+import com.dku.emptybear.domain.auth.dto.request.LogoutRequestDto;
 import com.dku.emptybear.domain.auth.dto.response.LoginResponseDto;
 import com.dku.emptybear.domain.auth.dto.response.SignupResponseDto;
+import com.dku.emptybear.domain.auth.dto.response.AuthMessageResponseDto;
 import com.dku.emptybear.domain.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -37,5 +41,22 @@ public class AuthController {
     @PostMapping("/login")
     public LoginResponseDto login(@Valid @RequestBody LoginRequestDto request) {
         return authService.login(request);
+    }
+
+    @Operation(
+            summary = "로그아웃",
+            description = "로그인된 사용자의 로그아웃을 처리하고, 리프레시 토큰을 무효화합니다."
+    )
+    @PostMapping("/logout")
+    public AuthMessageResponseDto logout(
+            @Parameter(
+                description = "액세스 토큰",
+                example = "Bearer access-token-example",
+                in = ParameterIn.HEADER
+            )
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+            @Valid @RequestBody LogoutRequestDto request
+    ) {
+        return authService.logout(authorizationHeader, request);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.dku.emptybear.domain.auth.controller;
 
+import com.dku.emptybear.domain.auth.dto.request.LoginRequestDto;
 import com.dku.emptybear.domain.auth.dto.request.SignupRequestDto;
+import com.dku.emptybear.domain.auth.dto.response.LoginResponseDto;
 import com.dku.emptybear.domain.auth.dto.response.SignupResponseDto;
 import com.dku.emptybear.domain.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,5 +28,14 @@ public class AuthController {
     @ResponseStatus(HttpStatus.CREATED)
     public SignupResponseDto signup(@Valid @RequestBody SignupRequestDto request) {
         return authService.signup(request);
+    }
+
+    @Operation(
+            summary = "로그인",
+            description = "사용자 식별 정보와 비밀번호를 입력받아 로그인하고, 인증 토큰 및 사용자 기본 정보를 반환합니다."
+    )
+    @PostMapping("/login")
+    public LoginResponseDto login(@Valid @RequestBody LoginRequestDto request) {
+        return authService.login(request);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/auth/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/dto/request/LoginRequestDto.java
@@ -1,0 +1,17 @@
+package com.dku.emptybear.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDto {
+
+    @Schema(description = "로그인 아이디", example = "emptybear01")
+    @NotBlank(message = "로그인 아이디는 필수입니다.")
+    private String loginId;
+
+    @Schema(description = "로그인 비밀번호", example = "qwer1234!")
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/dto/request/LogoutRequestDto.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/dto/request/LogoutRequestDto.java
@@ -1,0 +1,13 @@
+package com.dku.emptybear.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LogoutRequestDto {
+
+    @Schema(description = "로그아웃 처리 시 무효화할 리프레시 토큰", example = "refresh-token-example")
+    @NotBlank(message = "리프레시 토큰이 없습니다.")
+    private String refreshToken;
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/dto/request/ReissueRequestDto.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/dto/request/ReissueRequestDto.java
@@ -1,0 +1,13 @@
+package com.dku.emptybear.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ReissueRequestDto {
+
+    @Schema(description = "액세스 토큰 재발급에 사용하는 리프레시 토큰", example = "refresh-token-example")
+    @NotBlank(message = "리프레시 토큰이 없습니다.")
+    private String refreshToken;
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/dto/response/AuthMessageResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/dto/response/AuthMessageResponseDto.java
@@ -1,0 +1,13 @@
+package com.dku.emptybear.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AuthMessageResponseDto {
+
+    @Schema(description = "처리 결과 메시지", example = "로그아웃에 성공했습니다.")
+    private String message;
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/dto/response/LoginResponseDto.java
@@ -1,0 +1,39 @@
+package com.dku.emptybear.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponseDto {
+
+    @Schema(description = "인증이 필요한 API 호출에 사용하는 액세스 토큰", example = "access-token-example")
+    private String accessToken;
+
+    @Schema(description = "액세스 토큰 재발급에 사용하는 리프레시 토큰", example = "refresh-token-example")
+    private String refreshToken;
+
+    @Schema(description = "로그인한 사용자 정보")
+    private UserInfoDto user;
+
+    @Getter
+    @Builder
+    public static class UserInfoDto {
+
+        @Schema(description = "사용자 고유 ID", example = "1")
+        private Long userId;
+
+        @Schema(description = "사용자 로그인 아이디", example = "emptybear01")
+        private String loginId;
+
+        @Schema(description = "사용자 닉네임", example = "비었곰")
+        private String nickname;
+
+        @Schema(description = "사용자 학번", example = "32231234")
+        private String studentNumber;
+
+        @Schema(description = "사용자 학과", example = "소프트웨어학과")
+        private String department;
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/dto/response/ReissueResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/dto/response/ReissueResponseDto.java
@@ -1,0 +1,13 @@
+package com.dku.emptybear.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReissueResponseDto {
+
+    @Schema(description = "새로 발급된 액세스 토큰", example = "new-access-token-example")
+    private String accessToken;
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/jwt/JwtTokenProvider.java
@@ -1,6 +1,8 @@
 package com.dku.emptybear.domain.auth.jwt;
 
 import com.dku.emptybear.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -54,5 +56,27 @@ public class JwtTokenProvider {
                 .expiration(expiration)
                 .signWith(secretKey)
                 .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Long getUserId(String token) {
+        Claims claims = getClaims(token);
+        return Long.valueOf(claims.getSubject());
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,58 @@
+package com.dku.emptybear.domain.auth.jwt;
+
+import com.dku.emptybear.domain.user.entity.User;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    protected void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createAccessToken(User user) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + accessTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(user.getUserId()))
+                .claim("loginId", user.getLoginId())
+                .claim("nickname", user.getNickname())
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String createRefreshToken(User user) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + refreshTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(user.getUserId()))
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
@@ -1,15 +1,16 @@
 package com.dku.emptybear.domain.auth.service;
 
+import com.dku.emptybear.domain.auth.dto.request.LoginRequestDto;
 import com.dku.emptybear.domain.auth.dto.request.SignupRequestDto;
+import com.dku.emptybear.domain.auth.dto.response.LoginResponseDto;
 import com.dku.emptybear.domain.auth.dto.response.SignupResponseDto;
+import com.dku.emptybear.domain.auth.jwt.JwtTokenProvider;
 import com.dku.emptybear.domain.user.entity.User;
 import com.dku.emptybear.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +19,7 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public SignupResponseDto signup(SignupRequestDto request) {
         validateDuplicate(request);
@@ -53,5 +55,29 @@ public class AuthService {
         if (userRepository.existsByStudentNumber(request.getStudentNumber())) {
             throw new IllegalArgumentException("이미 등록된 학번입니다.");
         }
+    }
+
+    public LoginResponseDto login(LoginRequestDto request) {
+        User user = userRepository.findByLoginId(request.getLoginId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+
+        return LoginResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .user(LoginResponseDto.UserInfoDto.builder()
+                        .userId(user.getUserId())
+                        .loginId(user.getLoginId())
+                        .nickname(user.getNickname())
+                        .studentNumber(user.getStudentNumber())
+                        .department(user.getDepartment())
+                        .build())
+                .build();
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
@@ -3,9 +3,11 @@ package com.dku.emptybear.domain.auth.service;
 import com.dku.emptybear.domain.auth.dto.request.LoginRequestDto;
 import com.dku.emptybear.domain.auth.dto.request.LogoutRequestDto;
 import com.dku.emptybear.domain.auth.dto.request.SignupRequestDto;
+import com.dku.emptybear.domain.auth.dto.request.ReissueRequestDto;
 import com.dku.emptybear.domain.auth.dto.response.AuthMessageResponseDto;
 import com.dku.emptybear.domain.auth.dto.response.LoginResponseDto;
 import com.dku.emptybear.domain.auth.dto.response.SignupResponseDto;
+import com.dku.emptybear.domain.auth.dto.response.ReissueResponseDto;
 import com.dku.emptybear.domain.auth.jwt.JwtTokenProvider;
 import com.dku.emptybear.domain.user.entity.User;
 import com.dku.emptybear.domain.user.repository.UserRepository;
@@ -148,5 +150,32 @@ public class AuthService {
         }
 
         return normalizedToken;
+    }
+
+    public ReissueResponseDto reissue(ReissueRequestDto request) {
+        String refreshToken = request.getRefreshToken();
+
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        Long userId = jwtTokenProvider.getUserId(refreshToken);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        if (user.getRefreshToken() == null) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        if (!user.getRefreshToken().equals(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(user);
+
+        return ReissueResponseDto.builder()
+                .accessToken(newAccessToken)
+                .build();
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
@@ -78,7 +78,7 @@ public class AuthService {
     }
 
     public AuthMessageResponseDto logout(String authorizationHeader, LogoutRequestDto request) {
-        String accessToken = extractToken(authorizationHeader);
+        String accessToken = extractAccessToken(authorizationHeader);
         String refreshToken = normalizeToken(request.getRefreshToken());
 
         if (!jwtTokenProvider.validateToken(accessToken)) {
@@ -99,13 +99,7 @@ public class AuthService {
         User user = userRepository.findById(accessTokenUserId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-        if (user.getRefreshToken() == null) {
-            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
-        }
-
-        if (!user.getRefreshToken().equals(refreshToken)) {
-            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
-        }
+        validateStoredRefreshToken(user, refreshToken);
 
         user.clearRefreshToken();
 
@@ -128,7 +122,7 @@ public class AuthService {
         }
     }
 
-    private String extractToken(String authorizationHeader) {
+    private String extractAccessToken(String authorizationHeader) {
         String normalizedHeader = normalizeToken(authorizationHeader);
 
         if (normalizedHeader.isBlank()) {
@@ -153,10 +147,10 @@ public class AuthService {
     }
 
     public ReissueResponseDto reissue(ReissueRequestDto request) {
-        String refreshToken = request.getRefreshToken();
+        String refreshToken = normalizeToken(request.getRefreshToken());
 
         if (!jwtTokenProvider.validateToken(refreshToken)) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
 
         Long userId = jwtTokenProvider.getUserId(refreshToken);
@@ -164,18 +158,18 @@ public class AuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-        if (user.getRefreshToken() == null) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
-        }
-
-        if (!user.getRefreshToken().equals(refreshToken)) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
-        }
+        validateStoredRefreshToken(user, refreshToken);
 
         String newAccessToken = jwtTokenProvider.createAccessToken(user);
 
         return ReissueResponseDto.builder()
                 .accessToken(newAccessToken)
                 .build();
+    }
+
+    private void validateStoredRefreshToken(User user, String refreshToken) {
+        if (user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) {
+            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
+        }
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
@@ -1,7 +1,9 @@
 package com.dku.emptybear.domain.auth.service;
 
 import com.dku.emptybear.domain.auth.dto.request.LoginRequestDto;
+import com.dku.emptybear.domain.auth.dto.request.LogoutRequestDto;
 import com.dku.emptybear.domain.auth.dto.request.SignupRequestDto;
+import com.dku.emptybear.domain.auth.dto.response.AuthMessageResponseDto;
 import com.dku.emptybear.domain.auth.dto.response.LoginResponseDto;
 import com.dku.emptybear.domain.auth.dto.response.SignupResponseDto;
 import com.dku.emptybear.domain.auth.jwt.JwtTokenProvider;
@@ -11,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -43,6 +48,69 @@ public class AuthService {
                 .build();
     }
 
+    public LoginResponseDto login(LoginRequestDto request) {
+        User user = userRepository.findByLoginId(request.getLoginId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+
+        user.updateRefreshToken(refreshToken);
+
+        return LoginResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .user(LoginResponseDto.UserInfoDto.builder()
+                        .userId(user.getUserId())
+                        .loginId(user.getLoginId())
+                        .nickname(user.getNickname())
+                        .studentNumber(user.getStudentNumber())
+                        .department(user.getDepartment())
+                        .build())
+                .build();
+    }
+
+    public AuthMessageResponseDto logout(String authorizationHeader, LogoutRequestDto request) {
+        String accessToken = extractToken(authorizationHeader);
+        String refreshToken = request.getRefreshToken();
+
+        if (!jwtTokenProvider.validateToken(accessToken)) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        Long accessTokenUserId = jwtTokenProvider.getUserId(accessToken);
+        Long refreshTokenUserId = jwtTokenProvider.getUserId(refreshToken);
+
+        if (!Objects.equals(accessTokenUserId, refreshTokenUserId)) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        User user = userRepository.findById(accessTokenUserId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        if (user.getRefreshToken() == null) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        if (!user.getRefreshToken().equals(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        user.clearRefreshToken();
+
+        return AuthMessageResponseDto.builder()
+                .message("로그아웃에 성공했습니다.")
+                .build();
+    }
+
     private void validateDuplicate(SignupRequestDto request) {
         if (userRepository.existsByLoginId(request.getLoginId())) {
             throw new IllegalArgumentException("이미 사용 중인 로그인 아이디입니다.");
@@ -57,27 +125,11 @@ public class AuthService {
         }
     }
 
-    public LoginResponseDto login(LoginRequestDto request) {
-        User user = userRepository.findByLoginId(request.getLoginId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-
-        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+    private String extractToken(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
         }
 
-        String accessToken = jwtTokenProvider.createAccessToken(user);
-        String refreshToken = jwtTokenProvider.createRefreshToken(user);
-
-        return LoginResponseDto.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .user(LoginResponseDto.UserInfoDto.builder()
-                        .userId(user.getUserId())
-                        .loginId(user.getLoginId())
-                        .nickname(user.getNickname())
-                        .studentNumber(user.getStudentNumber())
-                        .department(user.getDepartment())
-                        .build())
-                .build();
+        return authorizationHeader.substring(7);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
@@ -14,13 +14,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class AuthService {
+
+    private static final String INVALID_TOKEN_MESSAGE = "유효하지 않은 토큰입니다.";
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -76,32 +77,32 @@ public class AuthService {
 
     public AuthMessageResponseDto logout(String authorizationHeader, LogoutRequestDto request) {
         String accessToken = extractToken(authorizationHeader);
-        String refreshToken = request.getRefreshToken();
+        String refreshToken = normalizeToken(request.getRefreshToken());
 
         if (!jwtTokenProvider.validateToken(accessToken)) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
 
         if (!jwtTokenProvider.validateToken(refreshToken)) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
 
         Long accessTokenUserId = jwtTokenProvider.getUserId(accessToken);
         Long refreshTokenUserId = jwtTokenProvider.getUserId(refreshToken);
 
         if (!Objects.equals(accessTokenUserId, refreshTokenUserId)) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
 
         User user = userRepository.findById(accessTokenUserId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
         if (user.getRefreshToken() == null) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
 
         if (!user.getRefreshToken().equals(refreshToken)) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
 
         user.clearRefreshToken();
@@ -126,10 +127,26 @@ public class AuthService {
     }
 
     private String extractToken(String authorizationHeader) {
-        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        String normalizedHeader = normalizeToken(authorizationHeader);
+
+        if (normalizedHeader.isBlank()) {
+            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
 
-        return authorizationHeader.substring(7);
+        return normalizedHeader;
+    }
+
+    private String normalizeToken(String token) {
+        if (token == null) {
+            return "";
+        }
+
+        String normalizedToken = token.trim();
+
+        while (normalizedToken.regionMatches(true, 0, "Bearer ", 0, 7)) {
+            normalizedToken = normalizedToken.substring(7).trim();
+        }
+
+        return normalizedToken;
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/user/entity/User.java
+++ b/src/main/java/com/dku/emptybear/domain/user/entity/User.java
@@ -37,6 +37,9 @@ public class User {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "refresh_token", length = 500)
+    private String refreshToken;
+
     @Builder
     public User(String loginId, String password, String nickname, String studentNumber, String department) {
         this.loginId = loginId;
@@ -49,5 +52,13 @@ public class User {
     @PrePersist
     public void prePersist() {
         this.createdAt = LocalDateTime.now();
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void clearRefreshToken() {
+        this.refreshToken = null;
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.dku.emptybear.domain.user.repository;
 import com.dku.emptybear.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByLoginId(String loginId);
@@ -10,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     boolean existsByStudentNumber(String studentNumber);
+
+    Optional<User> findByLoginId(String loginId);
 }


### PR DESCRIPTION
## 📝 개요 (Overview)
- JWT 기반 인증 API를 구현했습니다.
- 로그인, 로그아웃, 액세스 토큰 재발급 API를 추가했습니다.
- 로그인 성공 시 accessToken과 refreshToken을 발급하고, refreshToken은 사용자 정보에 저장하도록 구현했습니다.
- 로그아웃 시 accessToken과 refreshToken을 검증한 뒤 저장된 refreshToken을 무효화하도록 구현했습니다.

## 📌 이슈 번호 작성 (Related Issue)
- Closes #5 

## 🤔 작업 배경 및 목적 (Why)
- 인증이 필요한 API 호출을 위해 JWT 기반 로그인 기능이 필요했습니다.
- accessToken을 통해 인증이 필요한 요청을 처리하고, refreshToken을 통해 accessToken을 재발급할 수 있도록 구현했습니다.
- 로그아웃 시 서버에 저장된 refreshToken을 제거하여 이후 토큰 재발급이 불가능하도록 처리했습니다.
- Swagger에서 JWT 인증 헤더를 포함한 API 테스트가 가능하도록 Bearer 인증 설정을 추가했습니다.

## 🏷️ PR 유형 (Type of PR)
- [x] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [ ] 🎨 사용자 UI 디자인 변경
- [ ] ♻️ 코드 리팩토링
- [x] 📝 문서 수정 (Wiki, README 등)
- [ ] ✅ 테스트 추가 및 리팩토링
- [ ] 📁 파일 혹은 폴더 구조 수정 및 삭제

## 🛠️ 주요 변경 사항 (What)
- 로그인 API 추가
  - `POST /api/auth/login`
  - 로그인 아이디와 비밀번호 검증
  - accessToken, refreshToken 발급
  - 로그인한 사용자 기본 정보 반환
- 로그아웃 API 추가
  - `POST /api/auth/logout`
  - Authorization 헤더의 accessToken 검증
  - Request Body의 refreshToken 검증
  - accessToken과 refreshToken의 사용자 정보 일치 여부 확인
  - DB에 저장된 refreshToken과 요청 refreshToken 비교
  - 로그아웃 성공 시 refreshToken 무효화
- 액세스 토큰 재발급 API 추가
  - `POST /api/auth/reissue`
  - refreshToken 검증
  - DB에 저장된 refreshToken과 요청 refreshToken 비교
  - 유효한 경우 새 accessToken 발급
- JWT 관련 설정 추가
  - JWT secret 설정
  - accessToken 만료 시간 설정
  - refreshToken 만료 시간 설정
- `JwtTokenProvider` 추가
  - accessToken 생성
  - refreshToken 생성
  - 토큰 유효성 검증
  - 토큰에서 사용자 ID 추출
- `User` 엔티티에 refreshToken 저장 필드 및 갱신/삭제 메서드 추가
- Swagger Bearer JWT 인증 설정 추가
  - Swagger UI의 Authorize 버튼을 통해 accessToken 입력 가능
  - 로그아웃 API 테스트 시 Authorization 헤더 포함 가능
- 로그인, 로그아웃, 토큰 재발급 요청/응답 DTO 추가

## 📸 스크린 샷 (Optional)


## ✅ 체크리스트
- [x] 불필요한 주석/코드 및 디버깅용 로그 제거
- [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 단위 테스트 등)
- [x] 시뮬레이터 또는 실제 기기에서 정상 동작하는지 확인
- [x] 커밋 메시지 컨벤션을 준수 (*Commit message convention 참고)
- [ ] 관련 이슈를 닫는 커밋 메시지 사용 (Closes #)
- [x] PR 제목과 내용 명확히 작성

## 💬 리뷰 포인트 (To Reviewers)
- 로그인 성공 시 accessToken과 refreshToken이 정상 발급되는지 확인 부탁드립니다.
- refreshToken 저장 및 로그아웃 시 무효화 로직이 적절한지 확인 부탁드립니다.
- 로그아웃 API에서 accessToken과 refreshToken을 모두 검증하는 방식이 현재 인증 명세와 일치하는지 확인 부탁드립니다.
- 토큰 재발급 API에서 DB에 저장된 refreshToken과 요청 refreshToken을 비교하는 로직이 적절한지 확인 부탁드립니다.
- Swagger Bearer JWT 인증 설정이 API 테스트에 적절하게 적용되었는지 확인 부탁드립니다.