### PR TITLE
feat: JWT 인증 필터 구현

### DIFF
--- a/src/main/java/com/dku/emptybear/common/config/SecurityConfig.java
+++ b/src/main/java/com/dku/emptybear/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.dku.emptybear.common.config;
 
+import com.dku.emptybear.common.error.JwtAuthenticationEntryPoint;
 import com.dku.emptybear.domain.auth.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -26,6 +28,9 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .exceptionHandling(exception ->
+                        exception.authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(

--- a/src/main/java/com/dku/emptybear/common/config/SecurityConfig.java
+++ b/src/main/java/com/dku/emptybear/common/config/SecurityConfig.java
@@ -1,36 +1,46 @@
 package com.dku.emptybear.common.config;
 
+import com.dku.emptybear.domain.auth.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
-                .formLogin(form -> form.disable())
-                .httpBasic(httpBasic -> httpBasic.disable())
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/",
-                                "/login",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**",
-                                "/api-docs/**",
-                                "/webjars/**",
                                 "/api/auth/signup",
                                 "/api/auth/login",
-                                "/api/auth/logout",
                                 "/api/auth/reissue"
                         ).permitAll()
-                        .anyRequest().permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(
+                        jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();

--- a/src/main/java/com/dku/emptybear/common/error/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/dku/emptybear/common/error/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,6 @@
 package com.dku.emptybear.common.error;
 
+import com.dku.emptybear.domain.auth.jwt.JwtAuthenticationFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,9 +24,17 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
             HttpServletResponse response,
             AuthenticationException authException
     ) throws IOException {
+        boolean hasTokenError = Boolean.TRUE.equals(
+                request.getAttribute(JwtAuthenticationFilter.TOKEN_ERROR_ATTRIBUTE)
+        );
+
+        String message = hasTokenError
+                ? "유효하지 않거나 만료된 토큰입니다."
+                : "인증이 필요합니다.";
+
         ErrorResponse errorResponse = ErrorResponse.builder()
                 .status(HttpStatus.UNAUTHORIZED.value())
-                .message("인증이 필요합니다.")
+                .message(message)
                 .build();
 
         response.setStatus(HttpStatus.UNAUTHORIZED.value());

--- a/src/main/java/com/dku/emptybear/common/error/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/dku/emptybear/common/error/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.dku.emptybear.common.error;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(HttpStatus.UNAUTHORIZED.value())
+                .message("인증이 필요합니다.")
+                .build();
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.Authentication;
 
 @Tag(name = "Auth", description = "인증 관련 API")
 @RestController
@@ -51,10 +52,11 @@ public class AuthController {
     @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/logout")
     public AuthMessageResponseDto logout(
-            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+            Authentication authentication,
             @Valid @RequestBody LogoutRequestDto request
     ) {
-        return authService.logout(authorizationHeader, request);
+        Long userId = Long.valueOf(authentication.getName());
+        return authService.logout(userId, request);
     }
 
     @Operation(

--- a/src/main/java/com/dku/emptybear/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -32,8 +32,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         String token = extractToken(request);
 
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            Long userId = jwtTokenProvider.getUserId(token);
+        if (token != null && jwtTokenProvider.validateAccessToken(token)) {
+            Long userId = jwtTokenProvider.getUserIdFromValidAccessToken(token);
 
             Authentication authentication = new UsernamePasswordAuthenticationToken(
                     String.valueOf(userId),

--- a/src/main/java/com/dku/emptybear/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -19,6 +19,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    public static final String TOKEN_ERROR_ATTRIBUTE = "tokenError";
+
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
 
@@ -32,16 +34,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         String token = extractToken(request);
 
-        if (token != null && jwtTokenProvider.validateAccessToken(token)) {
-            Long userId = jwtTokenProvider.getUserIdFromValidAccessToken(token);
+        if (token != null) {
+            try {
+                Long userId = jwtTokenProvider.getUserIdFromValidAccessToken(token);
 
-            Authentication authentication = new UsernamePasswordAuthenticationToken(
-                    String.valueOf(userId),
-                    null,
-                    List.of(new SimpleGrantedAuthority("ROLE_USER"))
-            );
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        String.valueOf(userId),
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                );
 
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (RuntimeException e) {
+                request.setAttribute(TOKEN_ERROR_ATTRIBUTE, true);
+            }
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/dku/emptybear/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package com.dku.emptybear.domain.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String token = extractToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Long userId = jwtTokenProvider.getUserId(token);
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    String.valueOf(userId),
+                    null,
+                    List.of(new SimpleGrantedAuthority("ROLE_USER"))
+            );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (authorizationHeader == null || authorizationHeader.isBlank()) {
+            return null;
+        }
+
+        String token = authorizationHeader.trim();
+
+        while (token.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
+            token = token.substring(BEARER_PREFIX.length()).trim();
+        }
+
+        if (token.isBlank()) {
+            return null;
+        }
+
+        return token;
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/jwt/JwtTokenProvider.java
@@ -16,6 +16,10 @@ import java.util.Date;
 @Component
 public class JwtTokenProvider {
 
+    private static final String TOKEN_TYPE_CLAIM = "tokenType";
+    private static final String ACCESS_TOKEN_TYPE = "ACCESS";
+    private static final String REFRESH_TOKEN_TYPE = "REFRESH";
+
     @Value("${jwt.secret}")
     private String secret;
 
@@ -40,6 +44,7 @@ public class JwtTokenProvider {
                 .subject(String.valueOf(user.getUserId()))
                 .claim("loginId", user.getLoginId())
                 .claim("nickname", user.getNickname())
+                .claim(TOKEN_TYPE_CLAIM, ACCESS_TOKEN_TYPE)
                 .issuedAt(now)
                 .expiration(expiration)
                 .signWith(secretKey)
@@ -52,23 +57,48 @@ public class JwtTokenProvider {
 
         return Jwts.builder()
                 .subject(String.valueOf(user.getUserId()))
+                .claim(TOKEN_TYPE_CLAIM, REFRESH_TOKEN_TYPE)
                 .issuedAt(now)
                 .expiration(expiration)
                 .signWith(secretKey)
                 .compact();
     }
 
-    public boolean validateToken(String token) {
+    public boolean validateAccessToken(String token) {
         try {
-            getClaims(token);
-            return true;
+            Claims claims = getClaims(token);
+            return ACCESS_TOKEN_TYPE.equals(claims.get(TOKEN_TYPE_CLAIM, String.class));
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
     }
 
-    public Long getUserId(String token) {
+    public boolean validateRefreshToken(String token) {
+        try {
+            Claims claims = getClaims(token);
+            return REFRESH_TOKEN_TYPE.equals(claims.get(TOKEN_TYPE_CLAIM, String.class));
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Long getUserIdFromValidAccessToken(String token) {
         Claims claims = getClaims(token);
+
+        if (!ACCESS_TOKEN_TYPE.equals(claims.get(TOKEN_TYPE_CLAIM, String.class))) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        return Long.valueOf(claims.getSubject());
+    }
+
+    public Long getUserIdFromValidRefreshToken(String token) {
+        Claims claims = getClaims(token);
+
+        if (!REFRESH_TOKEN_TYPE.equals(claims.get(TOKEN_TYPE_CLAIM, String.class))) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
         return Long.valueOf(claims.getSubject());
     }
 

--- a/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
@@ -77,11 +77,10 @@ public class AuthService {
                 .build();
     }
 
-    public AuthMessageResponseDto logout(String authorizationHeader, LogoutRequestDto request) {
-        String accessToken = extractAccessToken(authorizationHeader);
+    public AuthMessageResponseDto logout(Long userId, LogoutRequestDto request) {
         String refreshToken = normalizeToken(request.getRefreshToken());
 
-        if (!jwtTokenProvider.validateToken(accessToken)) {
+        if (refreshToken.isBlank()) {
             throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
 
@@ -89,14 +88,13 @@ public class AuthService {
             throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
 
-        Long accessTokenUserId = jwtTokenProvider.getUserId(accessToken);
         Long refreshTokenUserId = jwtTokenProvider.getUserId(refreshToken);
 
-        if (!Objects.equals(accessTokenUserId, refreshTokenUserId)) {
+        if (!userId.equals(refreshTokenUserId)) {
             throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
 
-        User user = userRepository.findById(accessTokenUserId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
         validateStoredRefreshToken(user, refreshToken);

--- a/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dku/emptybear/domain/auth/service/AuthService.java
@@ -16,8 +16,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -84,11 +82,7 @@ public class AuthService {
             throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
 
-        if (!jwtTokenProvider.validateToken(refreshToken)) {
-            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
-        }
-
-        Long refreshTokenUserId = jwtTokenProvider.getUserId(refreshToken);
+        Long refreshTokenUserId = getUserIdFromRefreshToken(refreshToken);
 
         if (!userId.equals(refreshTokenUserId)) {
             throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
@@ -120,16 +114,6 @@ public class AuthService {
         }
     }
 
-    private String extractAccessToken(String authorizationHeader) {
-        String normalizedHeader = normalizeToken(authorizationHeader);
-
-        if (normalizedHeader.isBlank()) {
-            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
-        }
-
-        return normalizedHeader;
-    }
-
     private String normalizeToken(String token) {
         if (token == null) {
             return "";
@@ -147,11 +131,11 @@ public class AuthService {
     public ReissueResponseDto reissue(ReissueRequestDto request) {
         String refreshToken = normalizeToken(request.getRefreshToken());
 
-        if (!jwtTokenProvider.validateToken(refreshToken)) {
+        if (refreshToken.isBlank()) {
             throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
 
-        Long userId = jwtTokenProvider.getUserId(refreshToken);
+        Long userId = getUserIdFromRefreshToken(refreshToken);
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
@@ -167,6 +151,14 @@ public class AuthService {
 
     private void validateStoredRefreshToken(User user, String refreshToken) {
         if (user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) {
+            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
+        }
+    }
+
+    private Long getUserIdFromRefreshToken(String refreshToken) {
+        try {
+            return jwtTokenProvider.getUserIdFromValidRefreshToken(refreshToken);
+        } catch (RuntimeException e) {
             throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
         }
     }

--- a/src/main/java/com/dku/emptybear/domain/user/controller/UserController.java
+++ b/src/main/java/com/dku/emptybear/domain/user/controller/UserController.java
@@ -39,7 +39,7 @@ public class UserController {
     @PatchMapping("/me")
     public UpdateMyInfoResponseDto updateMyInfo(
             Authentication authentication,
-            @RequestBody UpdateMyInfoRequestDto request
+            @Valid @RequestBody UpdateMyInfoRequestDto request
     ) {
         Long userId = Long.valueOf(authentication.getName());
         return userService.updateMyInfo(userId, request);

--- a/src/main/java/com/dku/emptybear/domain/user/controller/UserController.java
+++ b/src/main/java/com/dku/emptybear/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.Authentication;
 
 @Tag(name = "Users", description = "사용자 관련 API")
 @RestController
@@ -25,10 +26,9 @@ public class UserController {
     )
     @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/me")
-    public MyInfoResponseDto getMyInfo(
-            @RequestHeader(value = "Authorization", required = false) String authorizationHeader
-    ) {
-        return userService.getMyInfo(authorizationHeader);
+    public MyInfoResponseDto getMyInfo(Authentication authentication) {
+        Long userId = Long.valueOf(authentication.getName());
+        return userService.getMyInfo(userId);
     }
 
     @Operation(
@@ -38,9 +38,10 @@ public class UserController {
     @SecurityRequirement(name = "bearerAuth")
     @PatchMapping("/me")
     public UpdateMyInfoResponseDto updateMyInfo(
-            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-            @Valid @RequestBody UpdateMyInfoRequestDto request
+            Authentication authentication,
+            @RequestBody UpdateMyInfoRequestDto request
     ) {
-        return userService.updateMyInfo(authorizationHeader, request);
+        Long userId = Long.valueOf(authentication.getName());
+        return userService.updateMyInfo(userId, request);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/user/service/UserService.java
+++ b/src/main/java/com/dku/emptybear/domain/user/service/UserService.java
@@ -15,14 +15,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserService {
 
-    private static final String INVALID_TOKEN_MESSAGE = "유효하지 않은 토큰입니다.";
-
     private final UserRepository userRepository;
-    private final JwtTokenProvider jwtTokenProvider;
 
-    public MyInfoResponseDto getMyInfo(String authorizationHeader) {
-        Long userId = getUserIdFromAuthorizationHeader(authorizationHeader);
-
+    public MyInfoResponseDto getMyInfo(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
@@ -38,11 +33,9 @@ public class UserService {
 
     @Transactional
     public UpdateMyInfoResponseDto updateMyInfo(
-            String authorizationHeader,
+            Long userId,
             UpdateMyInfoRequestDto request
     ) {
-        Long userId = getUserIdFromAuthorizationHeader(authorizationHeader);
-
         validateUpdateRequest(request);
 
         User user = userRepository.findById(userId)
@@ -65,35 +58,6 @@ public class UserService {
                         .department(user.getDepartment())
                         .build())
                 .build();
-    }
-
-    private Long getUserIdFromAuthorizationHeader(String authorizationHeader) {
-        String accessToken = extractAccessToken(authorizationHeader);
-
-        if (!jwtTokenProvider.validateToken(accessToken)) {
-            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
-        }
-
-        return jwtTokenProvider.getUserId(accessToken);
-    }
-
-    private String extractAccessToken(String authorizationHeader) {
-        if (authorizationHeader == null || authorizationHeader.isBlank()) {
-            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
-        }
-
-        String accessToken = authorizationHeader.trim();
-        String bearerPrefix = "Bearer ";
-
-        while (accessToken.regionMatches(true, 0, bearerPrefix, 0, bearerPrefix.length())) {
-            accessToken = accessToken.substring(bearerPrefix.length()).trim();
-        }
-
-        if (accessToken.isBlank()) {
-            throw new IllegalArgumentException(INVALID_TOKEN_MESSAGE);
-        }
-
-        return accessToken;
     }
 
     private void validateUpdateRequest(UpdateMyInfoRequestDto request) {

--- a/src/main/java/com/dku/emptybear/domain/user/service/UserService.java
+++ b/src/main/java/com/dku/emptybear/domain/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.dku.emptybear.domain.user.service;
 
-import com.dku.emptybear.domain.auth.jwt.JwtTokenProvider;
 import com.dku.emptybear.domain.user.dto.request.UpdateMyInfoRequestDto;
 import com.dku.emptybear.domain.user.dto.response.MyInfoResponseDto;
 import com.dku.emptybear.domain.user.dto.response.UpdateMyInfoResponseDto;


### PR DESCRIPTION
## 📝 개요 (Overview)
- JWT 인증 필터를 구현하여 accessToken 기반 인증 처리를 Spring Security Filter Chain에서 수행하도록 변경했습니다.
- 인증이 필요한 API 요청에서 Authorization 헤더의 Bearer 토큰을 검증하고, 인증된 사용자 정보를 SecurityContext에 저장하도록 구현했습니다.
- 인증 실패 시 기본 403 응답 대신 JSON 형태의 에러 응답을 반환하도록 처리했습니다.

## 📌 이슈 번호 작성 (Related Issue)
- Closes #9 

## 🤔 작업 배경 및 목적 (Why)
- 기존에는 각 Service에서 Authorization 헤더를 직접 파싱하고 accessToken을 검증하는 구조였습니다.
- 사용자 API, 즐겨찾기, 리뷰 등 앞으로 대부분의 API가 로그인 사용자를 필요로 하므로, 인증 로직이 여러 Service에 반복될 가능성이 있었습니다.
- JWT 인증 필터를 도입하여 인증 처리를 공통화하고, Controller 및 Service에서는 인증된 사용자 ID만 활용할 수 있도록 구조를 개선했습니다.
- 인증 실패 시 Swagger와 프론트엔드에서 원인을 확인하기 쉽도록 일관된 JSON 에러 응답을 제공하기 위해 인증 실패 응답 처리기를 추가했습니다.

## 🏷️ PR 유형 (Type of PR)
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 사용자 UI 디자인 변경
- [x] ♻️ 코드 리팩토링
- [ ] 📝 문서 수정 (Wiki, README 등)
- [ ] ✅ 테스트 추가 및 리팩토링
- [ ] 📁 파일 혹은 폴더 구조 수정 및 삭제

## 🛠️ 주요 변경 사항 (What)
- JWT 인증 필터 추가
  - Authorization 헤더에서 Bearer accessToken 추출
  - accessToken 유효성 검증
  - 토큰에서 사용자 ID 추출
  - 인증 성공 시 SecurityContext에 Authentication 저장

- SecurityConfig 인증 설정 수정
  - 세션을 사용하지 않도록 `STATELESS` 설정 적용
  - JWT 인증 필터를 Spring Security Filter Chain에 등록
  - 인증 없이 접근 가능한 Auth API와 Swagger 경로 설정
  - 그 외 요청은 인증이 필요하도록 설정

- 인증 실패 응답 처리 추가
  - 인증되지 않은 사용자가 보호된 API에 접근할 경우 JSON 에러 응답 반환
  - 응답 예시:
    ```json
    {
      "status": 401,
      "message": "인증이 필요합니다."
    }
    ```

- 사용자 API 인증 방식 수정
  - `/api/users/me` 조회/수정 API에서 Authorization 헤더를 직접 파싱하지 않도록 변경
  - SecurityContext의 Authentication에서 사용자 ID를 가져오도록 수정

- 로그아웃 API 인증 방식 수정
  - accessToken 검증은 JWT 인증 필터에서 처리
  - Service에서는 인증된 사용자 ID와 refreshToken을 기반으로 로그아웃 처리

## 📸 스크린 샷 (Optional)

## ✅ 체크리스트
- [x] 불필요한 주석/코드 및 디버깅용 로그 제거
- [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 단위 테스트 등)
- [x] 시뮬레이터 또는 실제 기기에서 정상 동작하는지 확인
- [x] 커밋 메시지 컨벤션을 준수 (*Commit message convention 참고)
- [x] 관련 이슈를 닫는 커밋 메시지 사용 (Closes #)
- [x] PR 제목과 내용 명확히 작성

## 💬 리뷰 포인트 (To Reviewers)
- JWT 인증 필터에서 Authorization 헤더를 정상적으로 추출하고 SecurityContext에 사용자 ID를 저장하는지 확인 부탁드립니다.
- SecurityConfig에서 인증이 필요한 API와 인증 없이 접근 가능한 API의 경로 설정이 적절한지 확인 부탁드립니다.
- 인증 실패 시 반환되는 JSON 응답 형식이 프로젝트의 ErrorResponse 구조와 일관되는지 확인 부탁드립니다.
- User API와 Logout API가 기존 Authorization 헤더 직접 검증 방식에서 SecurityContext 기반 방식으로 적절히 변경되었는지 확인 부탁드립니다.