### PR TITLE
feat: 건물 목록, 층 목록, 평면도 및 강의실 상태 조회 API 구현

### DIFF
--- a/src/main/java/com/dku/emptybear/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/dku/emptybear/domain/building/controller/BuildingController.java
@@ -1,6 +1,7 @@
 package com.dku.emptybear.domain.building.controller;
 
 import com.dku.emptybear.domain.building.dto.response.BuildingListResponseDto;
+import com.dku.emptybear.domain.building.dto.response.FloorClassroomStatusResponseDto;
 import com.dku.emptybear.domain.building.dto.response.FloorListResponseDto;
 import com.dku.emptybear.domain.building.dto.response.FloorPlanResponseDto;
 import com.dku.emptybear.domain.building.service.BuildingService;
@@ -56,5 +57,21 @@ public class BuildingController {
             @PathVariable Integer floorValue
     ) {
         return buildingService.getFloorPlan(buildingId, floorValue);
+    }
+
+    @Operation(
+            summary = "해당 층 강의실 상태 조회",
+            description = "특정 건물의 선택한 층에 위치한 강의실들의 평면도 표시 좌표와 현재 사용 상태 정보를 조회합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/{buildingId}/floors/{floorValue}/classrooms/status")
+    public FloorClassroomStatusResponseDto getClassroomStatuses(
+            @Parameter(description = "강의실 상태를 조회할 건물 ID", example = "1")
+            @PathVariable Long buildingId,
+
+            @Parameter(description = "강의실 상태를 조회할 층의 내부 값", example = "5")
+            @PathVariable Integer floorValue
+    ) {
+        return buildingService.getClassroomStatuses(buildingId, floorValue);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/dku/emptybear/domain/building/controller/BuildingController.java
@@ -2,6 +2,7 @@ package com.dku.emptybear.domain.building.controller;
 
 import com.dku.emptybear.domain.building.dto.response.BuildingListResponseDto;
 import com.dku.emptybear.domain.building.dto.response.FloorListResponseDto;
+import com.dku.emptybear.domain.building.dto.response.FloorPlanResponseDto;
 import com.dku.emptybear.domain.building.service.BuildingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -39,5 +40,21 @@ public class BuildingController {
             @PathVariable Long buildingId
     ) {
         return buildingService.getFloors(buildingId);
+    }
+
+    @Operation(
+            summary = "층별 평면도 조회",
+            description = "특정 건물의 선택한 층에 대한 평면도 이미지 정보를 조회합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/{buildingId}/floors/{floorValue}/floor-plan")
+    public FloorPlanResponseDto getFloorPlan(
+            @Parameter(description = "평면도를 조회할 건물 ID", example = "1")
+            @PathVariable Long buildingId,
+
+            @Parameter(description = "평면도를 조회할 층의 내부 값", example = "-1")
+            @PathVariable Integer floorValue
+    ) {
+        return buildingService.getFloorPlan(buildingId, floorValue);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/dku/emptybear/domain/building/controller/BuildingController.java
@@ -1,16 +1,18 @@
 package com.dku.emptybear.domain.building.controller;
 
 import com.dku.emptybear.domain.building.dto.response.BuildingListResponseDto;
+import com.dku.emptybear.domain.building.dto.response.FloorListResponseDto;
 import com.dku.emptybear.domain.building.service.BuildingService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Buildings", description = "건물 관련 API")
 @RestController
+@RequestMapping("/api/buildings")
 @RequiredArgsConstructor
 public class BuildingController {
 
@@ -18,11 +20,24 @@ public class BuildingController {
 
     @Operation(
             summary = "건물 목록 조회",
-            description = "서비스에서 조회 가능한 건물 목록을 반환합니다. 추천 조건 선택 및 지도 화면의 건물 선택에 사용됩니다."
+            description = "로그인한 사용자가 서비스에서 조회 가능한 건물 목록을 조회합니다. 추천 조건 선택 및 지도 화면의 건물 선택에 사용됩니다."
     )
     @SecurityRequirement(name = "bearerAuth")
-    @GetMapping("/api/buildings")
+    @GetMapping
     public BuildingListResponseDto getBuildings() {
         return buildingService.getBuildings();
+    }
+
+    @Operation(
+            summary = "층 목록 조회",
+            description = "특정 건물에서 조회 가능한 층 목록을 반환합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/{buildingId}/floors")
+    public FloorListResponseDto getFloors(
+            @Parameter(description = "층 목록을 조회할 건물 ID", example = "1")
+            @PathVariable Long buildingId
+    ) {
+        return buildingService.getFloors(buildingId);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/dku/emptybear/domain/building/controller/BuildingController.java
@@ -1,0 +1,28 @@
+package com.dku.emptybear.domain.building.controller;
+
+import com.dku.emptybear.domain.building.dto.response.BuildingListResponseDto;
+import com.dku.emptybear.domain.building.service.BuildingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Buildings", description = "건물 관련 API")
+@RestController
+@RequiredArgsConstructor
+public class BuildingController {
+
+    private final BuildingService buildingService;
+
+    @Operation(
+            summary = "건물 목록 조회",
+            description = "서비스에서 조회 가능한 건물 목록을 반환합니다. 추천 조건 선택 및 지도 화면의 건물 선택에 사용됩니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/api/buildings")
+    public BuildingListResponseDto getBuildings() {
+        return buildingService.getBuildings();
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/building/dto/response/BuildingListResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/building/dto/response/BuildingListResponseDto.java
@@ -1,0 +1,53 @@
+package com.dku.emptybear.domain.building.dto.response;
+
+import com.dku.emptybear.domain.building.entity.Building;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Builder
+public class BuildingListResponseDto {
+
+    @Schema(description = "건물 목록")
+    private List<BuildingInfoDto> buildings;
+
+    @Getter
+    @Builder
+    public static class BuildingInfoDto {
+
+        @Schema(description = "건물 고유 ID", example = "1")
+        private Long buildingId;
+
+        @Schema(description = "건물명", example = "소프트웨어ICT관")
+        private String buildingName;
+
+        @Schema(description = "캠퍼스명", example = "죽전", nullable = true)
+        private String campus;
+
+        @Schema(description = "건물 위도", example = "37.3214567", nullable = true)
+        private BigDecimal latitude;
+
+        @Schema(description = "건물 경도", example = "127.1265432", nullable = true)
+        private BigDecimal longitude;
+    }
+
+    public static BuildingListResponseDto from(List<Building> buildings) {
+        return BuildingListResponseDto.builder()
+                .buildings(
+                        buildings.stream()
+                                .map(building -> BuildingInfoDto.builder()
+                                        .buildingId(building.getBuildingId())
+                                        .buildingName(building.getBuildingName())
+                                        .campus(building.getCampus())
+                                        .latitude(building.getLatitude())
+                                        .longitude(building.getLongitude())
+                                        .build())
+                                .toList()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/building/dto/response/FloorClassroomStatusResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/building/dto/response/FloorClassroomStatusResponseDto.java
@@ -1,0 +1,55 @@
+package com.dku.emptybear.domain.building.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class FloorClassroomStatusResponseDto {
+
+    @Schema(description = "건물 고유 ID", example = "1")
+    private Long buildingId;
+
+    @Schema(description = "건물명", example = "소프트웨어ICT관")
+    private String buildingName;
+
+    @Schema(description = "층의 내부 값", example = "5")
+    private Integer floorValue;
+
+    @Schema(description = "사용자에게 표시할 층 이름", example = "5F")
+    private String floorLabel;
+
+    @Schema(description = "강의실 상태 목록")
+    private List<ClassroomStatusDto> classrooms;
+
+    @Getter
+    @Builder
+    public static class ClassroomStatusDto {
+
+        @Schema(description = "강의실 고유 ID", example = "12")
+        private Long classroomId;
+
+        @Schema(description = "강의실 호수", example = "516")
+        private String roomName;
+
+        @Schema(description = "평면도 이미지 기준 가로 비율 좌표", example = "0.4210")
+        private BigDecimal mapX;
+
+        @Schema(description = "평면도 이미지 기준 세로 비율 좌표", example = "0.3375")
+        private BigDecimal mapY;
+
+        @Schema(description = "현재 사용 상태 구분값", example = "AVAILABLE_LONG")
+        private String availabilityStatus;
+
+        @Schema(description = "현재 시점 기준 남은 사용 가능 시간(분)", example = "45")
+        private Integer availableMinutes;
+
+        @Schema(description = "다음 강의 시작 시각", example = "15:30", nullable = true)
+        private LocalTime nextClassStartTime;
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/building/dto/response/FloorListResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/building/dto/response/FloorListResponseDto.java
@@ -1,0 +1,61 @@
+package com.dku.emptybear.domain.building.dto.response;
+
+import com.dku.emptybear.domain.building.entity.Building;
+import com.dku.emptybear.domain.building.entity.FloorPlan;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class FloorListResponseDto {
+
+    @Schema(description = "건물 고유 ID", example = "1")
+    private Long buildingId;
+
+    @Schema(description = "건물명", example = "소프트웨어ICT관")
+    private String buildingName;
+
+    @Schema(description = "층 목록")
+    private List<FloorInfoDto> floors;
+
+    @Getter
+    @Builder
+    public static class FloorInfoDto {
+
+        @Schema(description = "층의 내부 값", example = "-1")
+        private Integer floorValue;
+
+        @Schema(description = "사용자에게 표시할 층 이름", example = "B1")
+        private String floorLabel;
+    }
+
+    public static FloorListResponseDto of(Building building, List<FloorPlan> floorPlans) {
+        return FloorListResponseDto.builder()
+                .buildingId(building.getBuildingId())
+                .buildingName(building.getBuildingName())
+                .floors(
+                        floorPlans.stream()
+                                .map(floorPlan -> FloorInfoDto.builder()
+                                        .floorValue(floorPlan.getFloor())
+                                        .floorLabel(toFloorLabel(floorPlan.getFloor()))
+                                        .build())
+                                .toList()
+                )
+                .build();
+    }
+
+    private static String toFloorLabel(Integer floor) {
+        if (floor == null) {
+            return null;
+        }
+
+        if (floor < 0) {
+            return "B" + Math.abs(floor);
+        }
+
+        return floor + "F";
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/building/dto/response/FloorPlanResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/building/dto/response/FloorPlanResponseDto.java
@@ -1,0 +1,62 @@
+package com.dku.emptybear.domain.building.dto.response;
+
+import com.dku.emptybear.domain.building.entity.FloorPlan;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FloorPlanResponseDto {
+
+    @Schema(description = "평면도 정보")
+    private FloorPlanInfoDto floorPlan;
+
+    @Getter
+    @Builder
+    public static class FloorPlanInfoDto {
+
+        @Schema(description = "평면도 고유 ID", example = "3")
+        private Long floorPlanId;
+
+        @Schema(description = "건물 고유 ID", example = "1")
+        private Long buildingId;
+
+        @Schema(description = "건물명", example = "소프트웨어ICT관")
+        private String buildingName;
+
+        @Schema(description = "층의 내부 값", example = "-1")
+        private Integer floorValue;
+
+        @Schema(description = "사용자에게 표시할 층 이름", example = "B1")
+        private String floorLabel;
+
+        @Schema(description = "평면도 이미지 URL", example = "https://example.com/floorplans/ict_b1.png")
+        private String imageUrl;
+    }
+
+    public static FloorPlanResponseDto from(FloorPlan floorPlan) {
+        return FloorPlanResponseDto.builder()
+                .floorPlan(FloorPlanInfoDto.builder()
+                        .floorPlanId(floorPlan.getFloorPlanId())
+                        .buildingId(floorPlan.getBuilding().getBuildingId())
+                        .buildingName(floorPlan.getBuilding().getBuildingName())
+                        .floorValue(floorPlan.getFloor())
+                        .floorLabel(toFloorLabel(floorPlan.getFloor()))
+                        .imageUrl(floorPlan.getImageUrl())
+                        .build())
+                .build();
+    }
+
+    private static String toFloorLabel(Integer floor) {
+        if (floor == null) {
+            return null;
+        }
+
+        if (floor < 0) {
+            return "B" + Math.abs(floor);
+        }
+
+        return floor + "F";
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/building/entity/Building.java
+++ b/src/main/java/com/dku/emptybear/domain/building/entity/Building.java
@@ -1,0 +1,32 @@
+package com.dku.emptybear.domain.building.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "building")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Building {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "building_id")
+    private Long buildingId;
+
+    @Column(name = "building_name", nullable = false, length = 100)
+    private String buildingName;
+
+    @Column(name = "campus", length = 50)
+    private String campus;
+
+    @Column(name = "latitude", precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(name = "longitude", precision = 10, scale = 7)
+    private BigDecimal longitude;
+}

--- a/src/main/java/com/dku/emptybear/domain/building/entity/FloorPlan.java
+++ b/src/main/java/com/dku/emptybear/domain/building/entity/FloorPlan.java
@@ -1,0 +1,38 @@
+package com.dku.emptybear.domain.building.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "floor_plan")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FloorPlan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "floor_plan_id")
+    private Long floorPlanId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "building_id", nullable = false)
+    private Building building;
+
+    @Column(name = "floor", nullable = false)
+    private Integer floor;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/building/repository/BuildingRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/building/repository/BuildingRepository.java
@@ -1,0 +1,7 @@
+package com.dku.emptybear.domain.building.repository;
+
+import com.dku.emptybear.domain.building.entity.Building;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BuildingRepository extends JpaRepository<Building, Long> {
+}

--- a/src/main/java/com/dku/emptybear/domain/building/repository/FloorPlanRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/building/repository/FloorPlanRepository.java
@@ -1,0 +1,11 @@
+package com.dku.emptybear.domain.building.repository;
+
+import com.dku.emptybear.domain.building.entity.FloorPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FloorPlanRepository extends JpaRepository<FloorPlan, Long> {
+
+    List<FloorPlan> findByBuilding_BuildingIdOrderByFloorAsc(Long buildingId);
+}

--- a/src/main/java/com/dku/emptybear/domain/building/repository/FloorPlanRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/building/repository/FloorPlanRepository.java
@@ -4,8 +4,11 @@ import com.dku.emptybear.domain.building.entity.FloorPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FloorPlanRepository extends JpaRepository<FloorPlan, Long> {
 
     List<FloorPlan> findByBuilding_BuildingIdOrderByFloorAsc(Long buildingId);
+    
+    Optional<FloorPlan> findByBuilding_BuildingIdAndFloor(Long buildingId, Integer floor);
 }

--- a/src/main/java/com/dku/emptybear/domain/building/service/BuildingService.java
+++ b/src/main/java/com/dku/emptybear/domain/building/service/BuildingService.java
@@ -2,6 +2,7 @@ package com.dku.emptybear.domain.building.service;
 
 import com.dku.emptybear.domain.building.dto.response.BuildingListResponseDto;
 import com.dku.emptybear.domain.building.dto.response.FloorListResponseDto;
+import com.dku.emptybear.domain.building.dto.response.FloorPlanResponseDto;
 import com.dku.emptybear.domain.building.entity.Building;
 import com.dku.emptybear.domain.building.entity.FloorPlan;
 import com.dku.emptybear.domain.building.repository.BuildingRepository;
@@ -33,5 +34,12 @@ public class BuildingService {
         List<FloorPlan> floorPlans = floorPlanRepository.findByBuilding_BuildingIdOrderByFloorAsc(buildingId);
 
         return FloorListResponseDto.of(building, floorPlans);
+    }
+
+    public FloorPlanResponseDto getFloorPlan(Long buildingId, Integer floorValue) {
+        FloorPlan floorPlan = floorPlanRepository.findByBuilding_BuildingIdAndFloor(buildingId, floorValue)
+                .orElseThrow(() -> new IllegalArgumentException("해당 층의 평면도가 존재하지 않습니다."));
+
+        return FloorPlanResponseDto.from(floorPlan);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/building/service/BuildingService.java
+++ b/src/main/java/com/dku/emptybear/domain/building/service/BuildingService.java
@@ -1,25 +1,41 @@
 package com.dku.emptybear.domain.building.service;
 
 import com.dku.emptybear.domain.building.dto.response.BuildingListResponseDto;
+import com.dku.emptybear.domain.building.dto.response.FloorClassroomStatusResponseDto;
 import com.dku.emptybear.domain.building.dto.response.FloorListResponseDto;
 import com.dku.emptybear.domain.building.dto.response.FloorPlanResponseDto;
 import com.dku.emptybear.domain.building.entity.Building;
 import com.dku.emptybear.domain.building.entity.FloorPlan;
 import com.dku.emptybear.domain.building.repository.BuildingRepository;
 import com.dku.emptybear.domain.building.repository.FloorPlanRepository;
+import com.dku.emptybear.domain.classroom.entity.Classroom;
+import com.dku.emptybear.domain.classroom.entity.Schedule;
+import com.dku.emptybear.domain.classroom.repository.ClassroomRepository;
+import com.dku.emptybear.domain.classroom.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.format.TextStyle;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BuildingService {
 
+    private static final int AVAILABLE_LONG_THRESHOLD_MINUTES = 30;
+
     private final BuildingRepository buildingRepository;
     private final FloorPlanRepository floorPlanRepository;
+    private final ClassroomRepository classroomRepository;
+    private final ScheduleRepository scheduleRepository;
 
     public BuildingListResponseDto getBuildings() {
         List<Building> buildings = buildingRepository.findAll();
@@ -41,5 +57,131 @@ public class BuildingService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 층의 평면도가 존재하지 않습니다."));
 
         return FloorPlanResponseDto.from(floorPlan);
+    }
+
+    public FloorClassroomStatusResponseDto getClassroomStatuses(Long buildingId, Integer floorValue) {
+        Building building = buildingRepository.findById(buildingId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 건물입니다."));
+
+        List<Classroom> classrooms = classroomRepository
+                .findByBuilding_BuildingIdAndFloorOrderByRoomNameAsc(buildingId, floorValue);
+
+        List<Long> classroomIds = classrooms.stream()
+                .map(Classroom::getClassroomId)
+                .toList();
+
+        String today = getTodayValue();
+        LocalTime now = LocalTime.now();
+
+        List<Schedule> schedules = classroomIds.isEmpty()
+                ? List.of()
+                : scheduleRepository.findByClassroom_ClassroomIdInAndDayOfWeekOrderByStartTimeAsc(
+                        classroomIds,
+                        today
+                );
+
+        Map<Long, List<Schedule>> scheduleMap = schedules.stream()
+                .collect(Collectors.groupingBy(schedule -> schedule.getClassroom().getClassroomId()));
+
+        List<FloorClassroomStatusResponseDto.ClassroomStatusDto> classroomStatusDtos = classrooms.stream()
+                .map(classroom -> {
+                    List<Schedule> classroomSchedules = scheduleMap.getOrDefault(
+                            classroom.getClassroomId(),
+                            List.of()
+                    );
+
+                    ClassroomAvailability availability = calculateAvailability(classroomSchedules, now);
+
+                    return FloorClassroomStatusResponseDto.ClassroomStatusDto.builder()
+                            .classroomId(classroom.getClassroomId())
+                            .roomName(classroom.getRoomName())
+                            .mapX(classroom.getMapX())
+                            .mapY(classroom.getMapY())
+                            .availabilityStatus(availability.status())
+                            .availableMinutes(availability.availableMinutes())
+                            .nextClassStartTime(availability.nextClassStartTime())
+                            .build();
+                })
+                .toList();
+
+        return FloorClassroomStatusResponseDto.builder()
+                .buildingId(building.getBuildingId())
+                .buildingName(building.getBuildingName())
+                .floorValue(floorValue)
+                .floorLabel(toFloorLabel(floorValue))
+                .classrooms(classroomStatusDtos)
+                .build();
+    }
+
+    private ClassroomAvailability calculateAvailability(
+            List<Schedule> schedules,
+            LocalTime now
+    ) {
+        List<Schedule> sortedSchedules = schedules.stream()
+                .sorted(Comparator.comparing(Schedule::getStartTime))
+                .toList();
+
+        for (Schedule schedule : sortedSchedules) {
+            if (!now.isBefore(schedule.getStartTime()) && now.isBefore(schedule.getEndTime())) {
+                return new ClassroomAvailability(
+                        "IN_USE",
+                        0,
+                        null
+                );
+            }
+
+            if (now.isBefore(schedule.getStartTime())) {
+                int availableMinutes = calculateMinutesBetween(now, schedule.getStartTime());
+
+                return new ClassroomAvailability(
+                        resolveAvailableStatus(availableMinutes),
+                        availableMinutes,
+                        schedule.getStartTime()
+                );
+            }
+        }
+
+        return new ClassroomAvailability(
+                "AVAILABLE_LONG",
+                0,
+                null
+        );
+    }
+
+    private String resolveAvailableStatus(int availableMinutes) {
+        if (availableMinutes >= AVAILABLE_LONG_THRESHOLD_MINUTES) {
+            return "AVAILABLE_LONG";
+        }
+
+        return "AVAILABLE_SHORT";
+    }
+
+    private int calculateMinutesBetween(LocalTime start, LocalTime end) {
+        return (int) java.time.Duration.between(start, end).toMinutes();
+    }
+
+    private String getTodayValue() {
+        DayOfWeek dayOfWeek = java.time.LocalDate.now().getDayOfWeek();
+
+        return dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.ENGLISH).toUpperCase();
+    }
+
+    private String toFloorLabel(Integer floor) {
+        if (floor == null) {
+            return null;
+        }
+
+        if (floor < 0) {
+            return "B" + Math.abs(floor);
+        }
+
+        return floor + "F";
+    }
+
+    private record ClassroomAvailability(
+            String status,
+            Integer availableMinutes,
+            LocalTime nextClassStartTime
+    ) {
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/building/service/BuildingService.java
+++ b/src/main/java/com/dku/emptybear/domain/building/service/BuildingService.java
@@ -1,0 +1,24 @@
+package com.dku.emptybear.domain.building.service;
+
+import com.dku.emptybear.domain.building.dto.response.BuildingListResponseDto;
+import com.dku.emptybear.domain.building.entity.Building;
+import com.dku.emptybear.domain.building.repository.BuildingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BuildingService {
+
+    private final BuildingRepository buildingRepository;
+
+    public BuildingListResponseDto getBuildings() {
+        List<Building> buildings = buildingRepository.findAll();
+
+        return BuildingListResponseDto.from(buildings);
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/building/service/BuildingService.java
+++ b/src/main/java/com/dku/emptybear/domain/building/service/BuildingService.java
@@ -1,8 +1,11 @@
 package com.dku.emptybear.domain.building.service;
 
 import com.dku.emptybear.domain.building.dto.response.BuildingListResponseDto;
+import com.dku.emptybear.domain.building.dto.response.FloorListResponseDto;
 import com.dku.emptybear.domain.building.entity.Building;
+import com.dku.emptybear.domain.building.entity.FloorPlan;
 import com.dku.emptybear.domain.building.repository.BuildingRepository;
+import com.dku.emptybear.domain.building.repository.FloorPlanRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,10 +18,20 @@ import java.util.List;
 public class BuildingService {
 
     private final BuildingRepository buildingRepository;
+    private final FloorPlanRepository floorPlanRepository;
 
     public BuildingListResponseDto getBuildings() {
         List<Building> buildings = buildingRepository.findAll();
 
         return BuildingListResponseDto.from(buildings);
+    }
+
+    public FloorListResponseDto getFloors(Long buildingId) {
+        Building building = buildingRepository.findById(buildingId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 건물입니다."));
+
+        List<FloorPlan> floorPlans = floorPlanRepository.findByBuilding_BuildingIdOrderByFloorAsc(buildingId);
+
+        return FloorListResponseDto.of(building, floorPlans);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/entity/Classroom.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/entity/Classroom.java
@@ -1,0 +1,48 @@
+package com.dku.emptybear.domain.classroom.entity;
+
+import com.dku.emptybear.domain.building.entity.Building;
+import com.dku.emptybear.domain.building.entity.FloorPlan;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "classroom")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Classroom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "classroom_id")
+    private Long classroomId;
+
+    @Column(name = "room_name", nullable = false, length = 50)
+    private String roomName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "building_id", nullable = false)
+    private Building building;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "floor_plan_id", nullable = false)
+    private FloorPlan floorPlan;
+
+    @Column(name = "floor", nullable = false)
+    private Integer floor;
+
+    @Column(name = "has_outlet", nullable = false)
+    private Boolean hasOutlet;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "map_x", precision = 5, scale = 4)
+    private BigDecimal mapX;
+
+    @Column(name = "map_y", precision = 5, scale = 4)
+    private BigDecimal mapY;
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/entity/Schedule.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/entity/Schedule.java
@@ -1,0 +1,36 @@
+package com.dku.emptybear.domain.classroom.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "schedule")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Schedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "schedule_id")
+    private Long scheduleId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "classroom_id", nullable = false)
+    private Classroom classroom;
+
+    @Column(name = "day_of_week", nullable = false, length = 20)
+    private String dayOfWeek;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "subject_name")
+    private String subjectName;
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ClassroomRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ClassroomRepository.java
@@ -1,0 +1,14 @@
+package com.dku.emptybear.domain.classroom.repository;
+
+import com.dku.emptybear.domain.classroom.entity.Classroom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ClassroomRepository extends JpaRepository<Classroom, Long> {
+
+    List<Classroom> findByBuilding_BuildingIdAndFloorOrderByRoomNameAsc(
+            Long buildingId,
+            Integer floor
+    );
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ScheduleRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ScheduleRepository.java
@@ -1,0 +1,15 @@
+package com.dku.emptybear.domain.classroom.repository;
+
+import com.dku.emptybear.domain.classroom.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    List<Schedule> findByClassroom_ClassroomIdInAndDayOfWeekOrderByStartTimeAsc(
+            Collection<Long> classroomIds,
+            String dayOfWeek
+    );
+}


### PR DESCRIPTION
## 📝 개요 (Overview)
- 건물 목록 조회, 층 목록 조회, 층별 평면도 조회, 해당 층 강의실 상태 조회 API를 구현했습니다.
- Buildings 도메인 하위에서 건물 및 층 기반 조회 기능을 제공하도록 Controller, Service, Repository, DTO, Entity를 추가 및 수정했습니다.

## 📌 이슈 번호 작성 (Related Issue)
- Closes #12 

## 🤔 작업 배경 및 목적 (Why)
- 사용자가 강의실을 탐색하기 위해서는 먼저 건물과 층을 선택할 수 있어야 합니다.
- 선택한 건물과 층을 기준으로 평면도 이미지를 조회하고, 해당 층에 위치한 강의실들의 좌표 및 현재 사용 상태를 표시할 필요가 있습니다.
- 지도 기반 강의실 조회 화면과 추천 조건 선택 기능에서 공통으로 사용할 건물 조회 API들을 제공하기 위해 구현했습니다.

## 🏷️ PR 유형 (Type of PR)
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 사용자 UI 디자인 변경
- [ ] ♻️ 코드 리팩토링
- [ ] 📝 문서 수정 (Wiki, README 등)
- [ ] ✅ 테스트 추가 및 리팩토링
- [x] 📁 파일 혹은 폴더 구조 수정 및 삭제

## 🛠️ 주요 변경 사항 (What)
- `GET /api/buildings`
  - 서비스에서 조회 가능한 건물 목록을 반환하는 API를 구현했습니다.
  - 건물 ID, 건물명, 캠퍼스, 위도, 경도 정보를 반환합니다.

- `GET /api/buildings/{buildingId}/floors`
  - 특정 건물에서 조회 가능한 층 목록을 반환하는 API를 구현했습니다.
  - `floorValue`와 사용자 표시용 `floorLabel`을 함께 반환합니다.
  - 예: `-1 → B1`, `1 → 1F`

- `GET /api/buildings/{buildingId}/floors/{floorValue}/floor-plan`
  - 특정 건물의 선택한 층에 대한 평면도 이미지 정보를 조회하는 API를 구현했습니다.
  - 평면도 ID, 건물 정보, 층 정보, 이미지 URL을 반환합니다.

- `GET /api/buildings/{buildingId}/floors/{floorValue}/classrooms/status`
  - 특정 건물의 선택한 층에 위치한 강의실들의 상태 조회 API를 구현했습니다.
  - 강의실 ID, 호수, 평면도 표시 좌표, 현재 사용 상태, 사용 가능 시간, 다음 강의 시작 시각을 반환합니다.
  - 현재 시간과 강의실 시간표를 기준으로 `IN_USE`, `AVAILABLE_SHORT`, `AVAILABLE_LONG` 상태를 계산합니다.

- `building`, `floor_plan`, `classroom`, `schedule` 테이블 조회를 위한 Entity 및 Repository를 추가했습니다.
- Swagger 문서화를 위해 각 API에 `@Operation`, `@Parameter`, `@SecurityRequirement(name = "bearerAuth")`를 적용했습니다.
- 로그인한 사용자 ID를 직접 사용하지 않는 API이지만, 인증된 사용자만 접근할 수 있도록 Bearer Token 인증 명세를 추가했습니다.

## 📸 스크린 샷 (Optional) 
-

## ✅ 체크리스트
- [x] 불필요한 주석/코드 및 디버깅용 로그 제거
- [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 단위 테스트 등)
- [x] 시뮬레이터 또는 실제 기기에서 정상 동작하는지 확인
- [x] 커밋 메시지 컨벤션을 준수 (*Commit message convention 참고)
- [x] 관련 이슈를 닫는 커밋 메시지 사용 (Closes #)
- [x] PR 제목과 내용 명확히 작성

## 💬 리뷰 포인트 (To Reviewers)
- `floorValue`를 사용자 표시용 `floorLabel`로 변환하는 방식이 적절한지 확인 부탁드립니다.
  - 현재는 `-1 → B1`, `-2 → B2`, `1 → 1F` 형식으로 변환합니다.
- 강의실 상태 계산 기준이 적절한지 확인 부탁드립니다.
  - 현재는 다음 강의까지 30분 이상 남으면 `AVAILABLE_LONG`, 30분 미만이면 `AVAILABLE_SHORT`로 처리합니다.
- `schedule.day_of_week` 저장 형식과 현재 요일 변환 방식이 일치하는지 확인 부탁드립니다.
- 건물 관련 조회 API들이 모두 인증 필요 API로 분류되는 것이 서비스 정책과 맞는지 확인 부탁드립니다.