### PR TITLE
feat: 기본 선호 설정 조회 및 수정 API 구현

### DIFF
--- a/src/main/java/com/dku/emptybear/domain/user/controller/UserController.java
+++ b/src/main/java/com/dku/emptybear/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.dku.emptybear.domain.user.controller;
 import com.dku.emptybear.domain.user.dto.request.UpdateMyInfoRequestDto;
 import com.dku.emptybear.domain.user.dto.response.MyInfoResponseDto;
 import com.dku.emptybear.domain.user.dto.response.UpdateMyInfoResponseDto;
+import com.dku.emptybear.domain.user.dto.response.UserPreferenceResponseDto;
 import com.dku.emptybear.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -43,5 +44,16 @@ public class UserController {
     ) {
         Long userId = Long.valueOf(authentication.getName());
         return userService.updateMyInfo(userId, request);
+    }
+
+    @Operation(
+            summary = "기본 선호 설정 조회",
+            description = "로그인한 사용자의 추천 기본값으로 사용할 선호 설정 정보를 조회합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/me/preferences")
+    public UserPreferenceResponseDto getMyPreference(Authentication authentication) {
+        Long userId = Long.valueOf(authentication.getName());
+        return userService.getMyPreference(userId);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/user/controller/UserController.java
+++ b/src/main/java/com/dku/emptybear/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.dku.emptybear.domain.user.controller;
 
 import com.dku.emptybear.domain.user.dto.request.UpdateMyInfoRequestDto;
+import com.dku.emptybear.domain.user.dto.request.UpdateUserPreferenceRequestDto;
 import com.dku.emptybear.domain.user.dto.response.MyInfoResponseDto;
 import com.dku.emptybear.domain.user.dto.response.UpdateMyInfoResponseDto;
 import com.dku.emptybear.domain.user.dto.response.UserPreferenceResponseDto;
@@ -55,5 +56,19 @@ public class UserController {
     public UserPreferenceResponseDto getMyPreference(Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());
         return userService.getMyPreference(userId);
+    }
+
+    @Operation(
+            summary = "기본 선호 설정 수정",
+            description = "로그인한 사용자의 추천 기본값으로 사용할 선호 건물, 최소 사용 가능 시간, 콘센트 필요 여부를 수정합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @PatchMapping("/me/preferences")
+    public UserPreferenceResponseDto updateMyPreference(
+            Authentication authentication,
+            @Valid @RequestBody UpdateUserPreferenceRequestDto request
+    ) {
+        Long userId = Long.valueOf(authentication.getName());
+        return userService.updateMyPreference(userId, request);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/user/dto/request/UpdateUserPreferenceRequestDto.java
+++ b/src/main/java/com/dku/emptybear/domain/user/dto/request/UpdateUserPreferenceRequestDto.java
@@ -1,0 +1,21 @@
+package com.dku.emptybear.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+@Getter
+public class UpdateUserPreferenceRequestDto {
+
+    @Schema(description = "선호 건물 ID", example = "3")
+    @Positive(message = "선호 건물 ID는 양수여야 합니다.")
+    private Long preferredBuildingId;
+
+    @Schema(description = "최소 사용 가능 시간(분)", example = "60")
+    @Min(value = 1, message = "최소 사용 가능 시간은 1분 이상이어야 합니다.")
+    private Integer minAvailableTime;
+
+    @Schema(description = "콘센트 필요 여부", example = "true")
+    private Boolean needOutlet;
+}

--- a/src/main/java/com/dku/emptybear/domain/user/dto/response/UserPreferenceResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/user/dto/response/UserPreferenceResponseDto.java
@@ -1,0 +1,38 @@
+package com.dku.emptybear.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserPreferenceResponseDto {
+
+    @Schema(description = "사용자 기본 선호 설정")
+    private PreferenceDto preference;
+
+    @Getter
+    @Builder
+    public static class PreferenceDto {
+
+        @Schema(description = "선호 건물 정보")
+        private PreferredBuildingDto preferredBuilding;
+
+        @Schema(description = "최소 사용 가능 시간(분)", example = "60")
+        private Integer minAvailableTime;
+
+        @Schema(description = "콘센트 필요 여부", example = "true")
+        private Boolean needOutlet;
+    }
+
+    @Getter
+    @Builder
+    public static class PreferredBuildingDto {
+
+        @Schema(description = "선호 건물 ID", example = "3")
+        private Long buildingId;
+
+        @Schema(description = "선호 건물명", example = "소프트웨어ICT관")
+        private String buildingName;
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/user/entity/UserPreference.java
+++ b/src/main/java/com/dku/emptybear/domain/user/entity/UserPreference.java
@@ -31,4 +31,42 @@ public class UserPreference {
     private Boolean needOutlet;
 
     private LocalDateTime updatedAt;
+
+    public static UserPreference create(
+            User user,
+            Building preferredBuilding,
+            Integer minAvailableTime,
+            Boolean needOutlet
+    ) {
+        UserPreference userPreference = new UserPreference();
+        userPreference.user = user;
+        userPreference.preferredBuilding = preferredBuilding;
+        userPreference.minAvailableTime = minAvailableTime;
+        userPreference.needOutlet = needOutlet;
+        return userPreference;
+    }
+
+    public void update(
+            Building preferredBuilding,
+            Integer minAvailableTime,
+            Boolean needOutlet
+    ) {
+        if (preferredBuilding != null) {
+            this.preferredBuilding = preferredBuilding;
+        }
+
+        if (minAvailableTime != null) {
+            this.minAvailableTime = minAvailableTime;
+        }
+
+        if (needOutlet != null) {
+            this.needOutlet = needOutlet;
+        }
+    }
+
+    @PrePersist
+    @PreUpdate
+    public void updateTimestamp() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/dku/emptybear/domain/user/entity/UserPreference.java
+++ b/src/main/java/com/dku/emptybear/domain/user/entity/UserPreference.java
@@ -16,6 +16,7 @@ public class UserPreference {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_preference_id")
     private Long userPreferenceId;
 
     @OneToOne(fetch = FetchType.LAZY)
@@ -26,10 +27,13 @@ public class UserPreference {
     @JoinColumn(name = "preferred_building_id")
     private Building preferredBuilding;
 
+    @Column(name = "min_available_time")
     private Integer minAvailableTime;
 
+    @Column(name = "need_outlet")
     private Boolean needOutlet;
 
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     public static UserPreference create(

--- a/src/main/java/com/dku/emptybear/domain/user/entity/UserPreference.java
+++ b/src/main/java/com/dku/emptybear/domain/user/entity/UserPreference.java
@@ -1,0 +1,34 @@
+package com.dku.emptybear.domain.user.entity;
+
+import com.dku.emptybear.domain.building.entity.Building;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "user_preferences")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPreference {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userPreferenceId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "preferred_building_id")
+    private Building preferredBuilding;
+
+    private Integer minAvailableTime;
+
+    private Boolean needOutlet;
+
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dku/emptybear/domain/user/repository/UserPreferenceRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/user/repository/UserPreferenceRepository.java
@@ -1,0 +1,11 @@
+package com.dku.emptybear.domain.user.repository;
+
+import com.dku.emptybear.domain.user.entity.UserPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
+
+    Optional<UserPreference> findByUser_UserId(Long userId);
+}

--- a/src/main/java/com/dku/emptybear/domain/user/service/UserService.java
+++ b/src/main/java/com/dku/emptybear/domain/user/service/UserService.java
@@ -3,8 +3,11 @@ package com.dku.emptybear.domain.user.service;
 import com.dku.emptybear.domain.user.dto.request.UpdateMyInfoRequestDto;
 import com.dku.emptybear.domain.user.dto.response.MyInfoResponseDto;
 import com.dku.emptybear.domain.user.dto.response.UpdateMyInfoResponseDto;
+import com.dku.emptybear.domain.user.dto.response.UserPreferenceResponseDto;
 import com.dku.emptybear.domain.user.entity.User;
+import com.dku.emptybear.domain.user.entity.UserPreference;
 import com.dku.emptybear.domain.user.repository.UserRepository;
+import com.dku.emptybear.domain.user.repository.UserPreferenceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserPreferenceRepository userPreferenceRepository;
 
     public MyInfoResponseDto getMyInfo(Long userId) {
         User user = userRepository.findById(userId)
@@ -100,5 +104,43 @@ public class UserService {
         }
 
         return value.trim();
+    }
+
+    public UserPreferenceResponseDto getMyPreference(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        return userPreferenceRepository.findByUser_UserId(userId)
+                .map(this::toUserPreferenceResponse)
+                .orElseGet(this::emptyPreferenceResponse);
+    }
+
+    private UserPreferenceResponseDto toUserPreferenceResponse(UserPreference userPreference) {
+        UserPreferenceResponseDto.PreferredBuildingDto preferredBuilding = null;
+
+        if (userPreference.getPreferredBuilding() != null) {
+            preferredBuilding = UserPreferenceResponseDto.PreferredBuildingDto.builder()
+                    .buildingId(userPreference.getPreferredBuilding().getBuildingId())
+                    .buildingName(userPreference.getPreferredBuilding().getBuildingName())
+                    .build();
+        }
+
+        return UserPreferenceResponseDto.builder()
+                .preference(UserPreferenceResponseDto.PreferenceDto.builder()
+                        .preferredBuilding(preferredBuilding)
+                        .minAvailableTime(userPreference.getMinAvailableTime())
+                        .needOutlet(userPreference.getNeedOutlet())
+                        .build())
+                .build();
+    }
+
+    private UserPreferenceResponseDto emptyPreferenceResponse() {
+        return UserPreferenceResponseDto.builder()
+                .preference(UserPreferenceResponseDto.PreferenceDto.builder()
+                        .preferredBuilding(null)
+                        .minAvailableTime(null)
+                        .needOutlet(null)
+                        .build())
+                .build();
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/user/service/UserService.java
+++ b/src/main/java/com/dku/emptybear/domain/user/service/UserService.java
@@ -111,9 +111,6 @@ public class UserService {
     }
 
     public UserPreferenceResponseDto getMyPreference(Long userId) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-
         return userPreferenceRepository.findByUser_UserId(userId)
                 .map(this::toUserPreferenceResponse)
                 .orElseGet(this::emptyPreferenceResponse);

--- a/src/main/java/com/dku/emptybear/domain/user/service/UserService.java
+++ b/src/main/java/com/dku/emptybear/domain/user/service/UserService.java
@@ -4,10 +4,13 @@ import com.dku.emptybear.domain.user.dto.request.UpdateMyInfoRequestDto;
 import com.dku.emptybear.domain.user.dto.response.MyInfoResponseDto;
 import com.dku.emptybear.domain.user.dto.response.UpdateMyInfoResponseDto;
 import com.dku.emptybear.domain.user.dto.response.UserPreferenceResponseDto;
+import com.dku.emptybear.domain.user.dto.request.UpdateUserPreferenceRequestDto;
 import com.dku.emptybear.domain.user.entity.User;
 import com.dku.emptybear.domain.user.entity.UserPreference;
+import com.dku.emptybear.domain.building.entity.Building;
 import com.dku.emptybear.domain.user.repository.UserRepository;
 import com.dku.emptybear.domain.user.repository.UserPreferenceRepository;
+import com.dku.emptybear.domain.building.repository.BuildingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +22,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final UserPreferenceRepository userPreferenceRepository;
+    private final BuildingRepository buildingRepository;
 
     public MyInfoResponseDto getMyInfo(Long userId) {
         User user = userRepository.findById(userId)
@@ -142,5 +146,57 @@ public class UserService {
                         .needOutlet(null)
                         .build())
                 .build();
+    }
+
+    @Transactional
+    public UserPreferenceResponseDto updateMyPreference(
+            Long userId,
+            UpdateUserPreferenceRequestDto request
+    ) {
+        validatePreferenceUpdateRequest(request);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        Building preferredBuilding = getPreferredBuilding(request.getPreferredBuildingId());
+
+        UserPreference userPreference = userPreferenceRepository.findByUser_UserId(userId)
+                .orElse(null);
+
+        if (userPreference == null) {
+            userPreference = UserPreference.create(
+                    user,
+                    preferredBuilding,
+                    request.getMinAvailableTime(),
+                    request.getNeedOutlet()
+            );
+
+            userPreferenceRepository.save(userPreference);
+        } else {
+            userPreference.update(
+                    preferredBuilding,
+                    request.getMinAvailableTime(),
+                    request.getNeedOutlet()
+            );
+        }
+
+        return toUserPreferenceResponse(userPreference);
+    }
+
+    private void validatePreferenceUpdateRequest(UpdateUserPreferenceRequestDto request) {
+        if (request.getPreferredBuildingId() == null
+                && request.getMinAvailableTime() == null
+                && request.getNeedOutlet() == null) {
+            throw new IllegalArgumentException("수정할 선호 설정 정보가 없습니다.");
+        }
+    }
+
+    private Building getPreferredBuilding(Long preferredBuildingId) {
+        if (preferredBuildingId == null) {
+            return null;
+        }
+
+        return buildingRepository.findById(preferredBuildingId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 건물입니다."));
     }
 }


### PR DESCRIPTION
## 📝 개요 (Overview)
- 로그인한 사용자의 기본 선호 설정 조회 및 수정 API를 구현했습니다.
- 사용자의 추천 기본값으로 사용할 선호 건물, 최소 사용 가능 시간, 콘센트 필요 여부를 저장하고 조회할 수 있도록 구현했습니다.
- 선호 설정이 없는 사용자의 경우 nullable 필드를 포함한 빈 선호 설정 응답을 반환하도록 처리했습니다.

## 📌 이슈 번호 작성 (Related Issue)
- Closes #11 

## 🤔 작업 배경 및 목적 (Why)
- 강의실 추천 기능에서 사용자별 기본 조건을 활용하기 위해 선호 설정 관리 기능이 필요했습니다.
- 사용자가 매번 추천 조건을 직접 입력하지 않아도, 저장된 기본 선호 설정을 기반으로 추천 조건을 초기화할 수 있도록 구현했습니다.
- 선호 건물 정보는 Buildings 도메인과 연동하여 건물 ID와 건물명을 함께 반환하도록 구성했습니다.

## 🏷️ PR 유형 (Type of PR)
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 사용자 UI 디자인 변경
- [ ] ♻️ 코드 리팩토링
- [ ] 📝 문서 수정 (Wiki, README 등)
- [ ] ✅ 테스트 추가 및 리팩토링
- [ ] 📁 파일 혹은 폴더 구조 수정 및 삭제

## 🛠️ 주요 변경 사항 (What)
- 기본 선호 설정 조회 API 추가
  - `GET /api/users/me/preferences`
  - 로그인한 사용자의 기본 선호 설정 조회
  - 선호 설정이 없는 경우 `preferredBuilding`, `minAvailableTime`, `needOutlet`을 `null`로 반환
  - 응답 정보: 선호 건물, 최소 사용 가능 시간, 콘센트 필요 여부

- 기본 선호 설정 수정 API 추가
  - `PATCH /api/users/me/preferences`
  - 로그인한 사용자의 선호 건물, 최소 사용 가능 시간, 콘센트 필요 여부 수정
  - 기존 선호 설정이 없으면 새로 생성
  - 기존 선호 설정이 있으면 요청된 필드 기준으로 갱신
  - 존재하지 않는 건물 ID 요청 시 예외 처리
  - 수정할 필드가 없는 빈 요청에 대한 예외 처리

- UserPreference 도메인 구성 추가
  - `UserPreference` 엔티티 추가
  - `UserPreferenceRepository` 추가
  - 기본 선호 설정 조회/수정 요청 및 응답 DTO 추가

- Buildings 도메인 연동
  - `preferredBuildingId`로 건물 존재 여부 확인
  - 응답에 `buildingId`, `buildingName` 포함

- Swagger 문서화 적용
  - 기본 선호 설정 조회/수정 API 설명 추가
  - JWT Bearer 인증이 필요한 API로 표시

## 📸 스크린 샷 (Optional)
- Swagger에서 `GET /api/users/me/preferences` 호출 후 기본 선호 설정 조회 확인
- Swagger에서 `PATCH /api/users/me/preferences` 호출 후 선호 건물, 최소 사용 가능 시간, 콘센트 필요 여부 수정 확인
- 선호 설정이 없는 사용자 조회 시 nullable 응답 확인
- 존재하지 않는 건물 ID 또는 빈 요청에 대한 예외 응답 확인

## ✅ 체크리스트
- [x] 불필요한 주석/코드 및 디버깅용 로그 제거
- [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 단위 테스트 등)
- [x] 시뮬레이터 또는 실제 기기에서 정상 동작하는지 확인
- [x] 커밋 메시지 컨벤션을 준수 (*Commit message convention 참고)
- [x] 관련 이슈를 닫는 커밋 메시지 사용 (Closes #)
- [x] PR 제목과 내용 명확히 작성

## 💬 리뷰 포인트 (To Reviewers)
- 선호 설정이 없는 경우 빈 객체 구조로 응답하는 방식이 프론트 처리에 적절한지 확인 부탁드립니다.
- 기본 선호 설정 수정 시 요청된 필드만 갱신하고, 누락된 필드는 기존 값을 유지하는 정책이 적절한지 확인 부탁드립니다.
- `preferredBuildingId`가 존재하지 않는 건물일 때 예외 처리하는 방식이 적절한지 확인 부탁드립니다.
- `UserPreference`와 `User`, `Building` 간 연관관계 매핑이 적절한지 확인 부탁드립니다.