### PR TITLE
feat: 강의실 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
@@ -1,0 +1,56 @@
+package com.dku.emptybear.domain.classroom.controller;
+
+import com.dku.emptybear.domain.classroom.dto.response.ClassroomOverviewListResponseDto;
+import com.dku.emptybear.domain.classroom.service.ClassroomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Classrooms", description = "강의실 관련 API")
+@RestController
+@RequestMapping("/api/classrooms")
+@RequiredArgsConstructor
+public class ClassroomController {
+
+    private final ClassroomService classroomService;
+
+    @Operation(
+            summary = "강의실 개요 목록 조회",
+            description = "건물, 층, 콘센트 여부, 사용 가능 상태 등의 조건에 맞는 강의실 개요 카드 목록을 조회합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping
+    public ClassroomOverviewListResponseDto getClassroomOverviews(
+            Authentication authentication,
+
+            @Parameter(description = "조회할 건물 ID", example = "1")
+            @RequestParam(required = false) Long buildingId,
+
+            @Parameter(description = "조회할 층의 내부 값", example = "5")
+            @RequestParam(required = false) Integer floorValue,
+
+            @Parameter(description = "콘센트 여부 필터", example = "true")
+            @RequestParam(required = false) Boolean hasOutlet,
+
+            @Parameter(description = "현재 사용 상태 필터", example = "AVAILABLE_LONG")
+            @RequestParam(required = false) String availabilityStatus,
+
+            @Parameter(description = "최소 사용 가능 시간(분) 필터", example = "30")
+            @RequestParam(required = false) Integer minAvailableTime
+    ) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return classroomService.getClassroomOverviews(
+                userId,
+                buildingId,
+                floorValue,
+                hasOutlet,
+                availabilityStatus,
+                minAvailableTime
+        );
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
@@ -1,5 +1,6 @@
 package com.dku.emptybear.domain.classroom.controller;
 
+import com.dku.emptybear.domain.classroom.dto.response.ClassroomDetailResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomOverviewListResponseDto;
 import com.dku.emptybear.domain.classroom.service.ClassroomService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,5 +53,22 @@ public class ClassroomController {
                 availabilityStatus,
                 minAvailableTime
         );
+    }
+
+    @Operation(
+            summary = "강의실 상세 정보 조회",
+            description = "특정 강의실의 상세 정보, 현재 사용 상태, 리뷰 요약, 건물 위치 정보를 조회합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/{classroomId}")
+    public ClassroomDetailResponseDto getClassroomDetail(
+            Authentication authentication,
+
+            @Parameter(description = "상세 정보를 조회할 강의실 ID", example = "12")
+            @PathVariable Long classroomId
+    ) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return classroomService.getClassroomDetail(userId, classroomId);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
@@ -2,6 +2,7 @@ package com.dku.emptybear.domain.classroom.controller;
 
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomDetailResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomOverviewListResponseDto;
+import com.dku.emptybear.domain.classroom.dto.response.ClassroomWeeklyScheduleResponseDto;
 import com.dku.emptybear.domain.classroom.service.ClassroomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -70,5 +71,18 @@ public class ClassroomController {
         Long userId = Long.valueOf(authentication.getName());
 
         return classroomService.getClassroomDetail(userId, classroomId);
+    }
+
+    @Operation(
+            summary = "강의실 주간 시간표 조회",
+            description = "특정 강의실의 주간 시간표 정보를 조회합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/{classroomId}/schedule")
+    public ClassroomWeeklyScheduleResponseDto getWeeklySchedule(
+            @Parameter(description = "시간표를 조회할 강의실 ID", example = "12")
+            @PathVariable Long classroomId
+    ) {
+        return classroomService.getWeeklySchedule(classroomId);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/dto/response/ClassroomDetailResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/dto/response/ClassroomDetailResponseDto.java
@@ -1,0 +1,92 @@
+package com.dku.emptybear.domain.classroom.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ClassroomDetailResponseDto {
+
+    @Schema(description = "강의실 상세 정보")
+    private ClassroomDetailDto classroom;
+
+    @Getter
+    @Builder
+    public static class ClassroomDetailDto {
+
+        @Schema(description = "강의실 고유 ID", example = "12")
+        private Long classroomId;
+
+        @Schema(description = "건물 정보")
+        private BuildingInfoDto building;
+
+        @Schema(description = "강의실 호수", example = "516")
+        private String roomName;
+
+        @Schema(description = "층의 내부 값", example = "5")
+        private Integer floorValue;
+
+        @Schema(description = "사용자에게 표시할 층 이름", example = "5F")
+        private String floorLabel;
+
+        @Schema(description = "콘센트 여부", example = "true")
+        private Boolean hasOutlet;
+
+        @Schema(description = "로그인 사용자의 즐겨찾기 여부", example = "true")
+        private Boolean isFavorite;
+
+        @Schema(description = "현재 사용 상태 구분값", example = "AVAILABLE_LONG")
+        private String availabilityStatus;
+
+        @Schema(description = "현재 시점 기준 남은 사용 가능 시간(분)", example = "45")
+        private Integer availableMinutes;
+
+        @Schema(description = "다음 강의 시작 시각", example = "15:30", nullable = true)
+        private String nextClassStartTime;
+
+        @Schema(description = "리뷰 요약")
+        private ReviewSummaryDto reviewSummary;
+    }
+
+    @Getter
+    @Builder
+    public static class BuildingInfoDto {
+
+        @Schema(description = "건물 고유 ID", example = "1")
+        private Long buildingId;
+
+        @Schema(description = "건물명", example = "소프트웨어ICT관")
+        private String buildingName;
+    }
+
+    @Getter
+    @Builder
+    public static class ReviewSummaryDto {
+
+        @Schema(description = "전체 리뷰 개수", example = "18")
+        private Integer totalReviewCount;
+
+        @Schema(description = "태그별 리뷰 개수")
+        private List<TagSummaryDto> tags;
+    }
+
+    @Getter
+    @Builder
+    public static class TagSummaryDto {
+
+        @Schema(description = "태그 고유 ID", example = "1")
+        private Long tagId;
+
+        @Schema(description = "태그 내부 코드값", example = "QUIET")
+        private String code;
+
+        @Schema(description = "태그 표시명", example = "조용해요")
+        private String displayName;
+
+        @Schema(description = "해당 태그가 선택된 리뷰 개수", example = "8")
+        private Integer count;
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/dto/response/ClassroomOverviewListResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/dto/response/ClassroomOverviewListResponseDto.java
@@ -1,0 +1,47 @@
+package com.dku.emptybear.domain.classroom.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ClassroomOverviewListResponseDto {
+
+    @Schema(description = "강의실 개요 목록")
+    private List<ClassroomOverviewDto> classrooms;
+
+    @Getter
+    @Builder
+    public static class ClassroomOverviewDto {
+
+        @Schema(description = "강의실 고유 ID", example = "12")
+        private Long classroomId;
+
+        @Schema(description = "건물명", example = "소프트웨어ICT관")
+        private String buildingName;
+
+        @Schema(description = "강의실 호수", example = "516")
+        private String roomName;
+
+        @Schema(description = "사용자에게 표시할 층 이름", example = "5F")
+        private String floorLabel;
+
+        @Schema(description = "콘센트 여부", example = "true")
+        private Boolean hasOutlet;
+
+        @Schema(description = "로그인 사용자의 즐겨찾기 여부", example = "true")
+        private Boolean isFavorite;
+
+        @Schema(description = "현재 사용 상태 구분값", example = "AVAILABLE_LONG")
+        private String availabilityStatus;
+
+        @Schema(description = "현재 시점 기준 남은 사용 가능 시간(분)", example = "45")
+        private Integer availableMinutes;
+
+        @Schema(description = "다음 강의 시작 시각", example = "15:30", nullable = true)
+        private String nextClassStartTime;
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/dto/response/ClassroomWeeklyScheduleResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/dto/response/ClassroomWeeklyScheduleResponseDto.java
@@ -1,0 +1,38 @@
+package com.dku.emptybear.domain.classroom.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ClassroomWeeklyScheduleResponseDto {
+
+    @Schema(description = "강의실 고유 ID", example = "12")
+    private Long classroomId;
+
+    @Schema(description = "강의실 주간 시간표")
+    private List<ScheduleInfoDto> weeklySchedule;
+
+    @Getter
+    @Builder
+    public static class ScheduleInfoDto {
+
+        @Schema(description = "시간표 고유 ID", example = "101")
+        private Long scheduleId;
+
+        @Schema(description = "요일", example = "MON")
+        private String dayOfWeek;
+
+        @Schema(description = "시작 시각", example = "09:00")
+        private String startTime;
+
+        @Schema(description = "종료 시각", example = "10:15")
+        private String endTime;
+
+        @Schema(description = "수업명", example = "자료구조", nullable = true)
+        private String subjectName;
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/entity/Favorite.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/entity/Favorite.java
@@ -9,7 +9,13 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "favorite")
+@Table(
+        name = "favorite",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_favorite_user_classroom",
+                columnNames = {"user_id", "classroom_id"}
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Favorite {

--- a/src/main/java/com/dku/emptybear/domain/classroom/entity/Favorite.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/entity/Favorite.java
@@ -1,0 +1,37 @@
+package com.dku.emptybear.domain.classroom.entity;
+
+import com.dku.emptybear.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "favorite")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Favorite {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "favorite_id")
+    private Long favoriteId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "classroom_id", nullable = false)
+    private Classroom classroom;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/entity/Review.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/entity/Review.java
@@ -37,4 +37,9 @@ public class Review {
     public void prePersist() {
         this.createdAt = LocalDateTime.now();
     }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/entity/Review.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/entity/Review.java
@@ -1,0 +1,40 @@
+package com.dku.emptybear.domain.classroom.entity;
+
+import com.dku.emptybear.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "review")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    private Long reviewId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "classroom_id", nullable = false)
+    private Classroom classroom;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/entity/ReviewTag.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/entity/ReviewTag.java
@@ -1,0 +1,27 @@
+package com.dku.emptybear.domain.classroom.entity;
+
+import com.dku.emptybear.domain.tag.entity.Tag;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "review_tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_tag_id")
+    private Long reviewTagId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/entity/ReviewTag.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/entity/ReviewTag.java
@@ -7,7 +7,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "review_tag")
+@Table(
+        name = "review_tag",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_review_tag_review_tag",
+                columnNames = {"review_id", "tag_id"}
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReviewTag {

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ClassroomRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ClassroomRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ClassroomRepository extends JpaRepository<Classroom, Long> {
 
@@ -28,4 +29,12 @@ public interface ClassroomRepository extends JpaRepository<Classroom, Long> {
             @Param("floorValue") Integer floorValue,
             @Param("hasOutlet") Boolean hasOutlet
     );
+
+    @Query("""
+            SELECT c
+            FROM Classroom c
+            JOIN FETCH c.building b
+            WHERE c.classroomId = :classroomId
+            """)
+    Optional<Classroom> findByIdWithBuilding(@Param("classroomId") Long classroomId);
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ClassroomRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ClassroomRepository.java
@@ -2,6 +2,8 @@ package com.dku.emptybear.domain.classroom.repository;
 
 import com.dku.emptybear.domain.classroom.entity.Classroom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,5 +12,20 @@ public interface ClassroomRepository extends JpaRepository<Classroom, Long> {
     List<Classroom> findByBuilding_BuildingIdAndFloorOrderByRoomNameAsc(
             Long buildingId,
             Integer floor
+    );
+
+    @Query("""
+            SELECT c
+            FROM Classroom c
+            JOIN FETCH c.building b
+            WHERE (:buildingId IS NULL OR b.buildingId = :buildingId)
+              AND (:floorValue IS NULL OR c.floor = :floorValue)
+              AND (:hasOutlet IS NULL OR c.hasOutlet = :hasOutlet)
+            ORDER BY b.buildingName ASC, c.floor ASC, c.roomName ASC
+            """)
+    List<Classroom> findClassroomsByFilters(
+            @Param("buildingId") Long buildingId,
+            @Param("floorValue") Integer floorValue,
+            @Param("hasOutlet") Boolean hasOutlet
     );
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/FavoriteRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/FavoriteRepository.java
@@ -12,4 +12,9 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
             Long userId,
             Collection<Long> classroomIds
     );
+
+    boolean existsByUser_UserIdAndClassroom_ClassroomId(
+            Long userId,
+            Long classroomId
+    );
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/FavoriteRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/FavoriteRepository.java
@@ -1,0 +1,15 @@
+package com.dku.emptybear.domain.classroom.repository;
+
+import com.dku.emptybear.domain.classroom.entity.Favorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    List<Favorite> findByUser_UserIdAndClassroom_ClassroomIdIn(
+            Long userId,
+            Collection<Long> classroomIds
+    );
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewRepository.java
@@ -1,0 +1,9 @@
+package com.dku.emptybear.domain.classroom.repository;
+
+import com.dku.emptybear.domain.classroom.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    long countByClassroom_ClassroomId(Long classroomId);
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewTagRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewTagRepository.java
@@ -1,0 +1,37 @@
+package com.dku.emptybear.domain.classroom.repository;
+
+import com.dku.emptybear.domain.classroom.entity.ReviewTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
+
+    @Query("""
+            SELECT
+                t.tagId AS tagId,
+                t.code AS code,
+                t.displayName AS displayName,
+                COUNT(rt.reviewTagId) AS count
+            FROM ReviewTag rt
+            JOIN rt.review r
+            JOIN rt.tag t
+            WHERE r.classroom.classroomId = :classroomId
+            GROUP BY t.tagId, t.code, t.displayName
+            ORDER BY COUNT(rt.reviewTagId) DESC, t.tagId ASC
+            """)
+    List<TagCountProjection> countTagsByClassroomId(@Param("classroomId") Long classroomId);
+
+    interface TagCountProjection {
+
+        Long getTagId();
+
+        String getCode();
+
+        String getDisplayName();
+
+        Long getCount();
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ScheduleRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ScheduleRepository.java
@@ -17,4 +17,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             Long classroomId,
             String dayOfWeek
     );
+
+    List<Schedule> findByClassroom_ClassroomId(Long classroomId);
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ScheduleRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ScheduleRepository.java
@@ -12,4 +12,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             Collection<Long> classroomIds,
             String dayOfWeek
     );
+
+    List<Schedule> findByClassroom_ClassroomIdAndDayOfWeekOrderByStartTimeAsc(
+            Long classroomId,
+            String dayOfWeek
+    );
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
@@ -293,9 +293,11 @@ public class ClassroomService {
             }
         }
 
+        int availableMinutes = calculateMinutesBetween(now, END_OF_DAY);
+
         return new ClassroomAvailability(
-                "AVAILABLE_LONG",
-                calculateMinutesBetween(now, END_OF_DAY),
+                resolveAvailableStatus(availableMinutes),
+                availableMinutes,
                 null
         );
     }

--- a/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
@@ -2,6 +2,7 @@ package com.dku.emptybear.domain.classroom.service;
 
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomDetailResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomOverviewListResponseDto;
+import com.dku.emptybear.domain.classroom.dto.response.ClassroomWeeklyScheduleResponseDto;
 import com.dku.emptybear.domain.classroom.entity.Classroom;
 import com.dku.emptybear.domain.classroom.entity.Favorite;
 import com.dku.emptybear.domain.classroom.entity.Schedule;
@@ -164,6 +165,56 @@ public class ClassroomService {
                                 .build())
                         .build())
                 .build();
+    }
+
+    /**
+     * 특정 강의실의 주간 시간표를 조회한다.
+     */
+    public ClassroomWeeklyScheduleResponseDto getWeeklySchedule(Long classroomId) {
+        classroomRepository.findById(classroomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의실입니다."));
+
+        List<Schedule> schedules = scheduleRepository.findByClassroom_ClassroomId(classroomId);
+
+        List<ClassroomWeeklyScheduleResponseDto.ScheduleInfoDto> weeklySchedule = schedules.stream()
+                // dayOfWeek는 문자열이므로 MON~SUN 순서가 보장되도록 직접 정렬한다.
+                .sorted(
+                        Comparator.comparingInt((Schedule schedule) -> getDayOfWeekOrder(schedule.getDayOfWeek()))
+                                .thenComparing(Schedule::getStartTime)
+                )
+                .map(schedule -> ClassroomWeeklyScheduleResponseDto.ScheduleInfoDto.builder()
+                        .scheduleId(schedule.getScheduleId())
+                        .dayOfWeek(schedule.getDayOfWeek())
+                        .startTime(formatTime(schedule.getStartTime()))
+                        .endTime(formatTime(schedule.getEndTime()))
+                        .subjectName(schedule.getSubjectName())
+                        .build())
+                .toList();
+
+        return ClassroomWeeklyScheduleResponseDto.builder()
+                .classroomId(classroomId)
+                .weeklySchedule(weeklySchedule)
+                .build();
+    }
+
+    /**
+     * 요일 문자열을 주간 정렬 순서로 변환한다.
+     */
+    private int getDayOfWeekOrder(String dayOfWeek) {
+        if (dayOfWeek == null) {
+            return 99;
+        }
+
+        return switch (dayOfWeek) {
+            case "MON" -> 1;
+            case "TUE" -> 2;
+            case "WED" -> 3;
+            case "THU" -> 4;
+            case "FRI" -> 5;
+            case "SAT" -> 6;
+            case "SUN" -> 7;
+            default -> 99;
+        };
     }
 
     /**

--- a/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
@@ -1,11 +1,14 @@
 package com.dku.emptybear.domain.classroom.service;
 
+import com.dku.emptybear.domain.classroom.dto.response.ClassroomDetailResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomOverviewListResponseDto;
 import com.dku.emptybear.domain.classroom.entity.Classroom;
 import com.dku.emptybear.domain.classroom.entity.Favorite;
 import com.dku.emptybear.domain.classroom.entity.Schedule;
 import com.dku.emptybear.domain.classroom.repository.ClassroomRepository;
 import com.dku.emptybear.domain.classroom.repository.FavoriteRepository;
+import com.dku.emptybear.domain.classroom.repository.ReviewRepository;
+import com.dku.emptybear.domain.classroom.repository.ReviewTagRepository;
 import com.dku.emptybear.domain.classroom.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,6 +39,8 @@ public class ClassroomService {
     private final ClassroomRepository classroomRepository;
     private final ScheduleRepository scheduleRepository;
     private final FavoriteRepository favoriteRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReviewTagRepository reviewTagRepository;
 
     /**
      * 조건에 맞는 강의실 개요 목록을 조회한다.
@@ -101,6 +106,63 @@ public class ClassroomService {
 
         return ClassroomOverviewListResponseDto.builder()
                 .classrooms(result)
+                .build();
+    }
+
+    /**
+     * 특정 강의실의 상세 정보, 현재 사용 상태, 즐겨찾기 여부, 리뷰 요약 정보를 조회한다.
+     */
+    public ClassroomDetailResponseDto getClassroomDetail(Long userId, Long classroomId) {
+        Classroom classroom = classroomRepository.findByIdWithBuilding(classroomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의실입니다."));
+
+        boolean isFavorite = favoriteRepository.existsByUser_UserIdAndClassroom_ClassroomId(
+                userId,
+                classroomId
+        );
+
+        List<Schedule> todaySchedules = scheduleRepository.findByClassroom_ClassroomIdAndDayOfWeekOrderByStartTimeAsc(
+                classroomId,
+                getTodayValue()
+        );
+
+        ClassroomAvailability availability = calculateAvailability(todaySchedules, LocalTime.now());
+
+        int totalReviewCount = Math.toIntExact(
+                reviewRepository.countByClassroom_ClassroomId(classroomId)
+        );
+
+        List<ClassroomDetailResponseDto.TagSummaryDto> tagSummaries =
+                reviewTagRepository.countTagsByClassroomId(classroomId)
+                        .stream()
+                        .map(tagCount -> ClassroomDetailResponseDto.TagSummaryDto.builder()
+                                .tagId(tagCount.getTagId())
+                                .code(tagCount.getCode())
+                                .displayName(tagCount.getDisplayName())
+                                .count(Math.toIntExact(tagCount.getCount()))
+                                .build())
+                        .toList();
+
+        return ClassroomDetailResponseDto.builder()
+                .classroom(ClassroomDetailResponseDto.ClassroomDetailDto.builder()
+                        .classroomId(classroom.getClassroomId())
+                        .building(ClassroomDetailResponseDto.BuildingInfoDto.builder()
+                                .buildingId(classroom.getBuilding().getBuildingId())
+                                .buildingName(classroom.getBuilding().getBuildingName())
+                                .build())
+                        .roomName(classroom.getRoomName())
+                        .floorValue(classroom.getFloor())
+                        .floorLabel(toFloorLabel(classroom.getFloor()))
+                        .hasOutlet(classroom.getHasOutlet())
+                        .isFavorite(isFavorite)
+                        .availabilityStatus(availability.status())
+                        .availableMinutes(availability.availableMinutes())
+                        .nextClassStartTime(formatTime(availability.nextClassStartTime()))
+                        .reviewSummary(ClassroomDetailResponseDto.ReviewSummaryDto.builder()
+                                .totalReviewCount(totalReviewCount)
+                                .tags(tagSummaries)
+                                .build())
+                        .build())
                 .build();
     }
 

--- a/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
@@ -1,0 +1,252 @@
+package com.dku.emptybear.domain.classroom.service;
+
+import com.dku.emptybear.domain.classroom.dto.response.ClassroomOverviewListResponseDto;
+import com.dku.emptybear.domain.classroom.entity.Classroom;
+import com.dku.emptybear.domain.classroom.entity.Favorite;
+import com.dku.emptybear.domain.classroom.entity.Schedule;
+import com.dku.emptybear.domain.classroom.repository.ClassroomRepository;
+import com.dku.emptybear.domain.classroom.repository.FavoriteRepository;
+import com.dku.emptybear.domain.classroom.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClassroomService {
+
+    private static final int AVAILABLE_LONG_THRESHOLD_MINUTES = 30;
+    private static final LocalTime END_OF_DAY = LocalTime.of(23, 59);
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final ClassroomRepository classroomRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final FavoriteRepository favoriteRepository;
+
+    /**
+     * 조건에 맞는 강의실 개요 목록을 조회한다.
+     * availabilityStatus와 minAvailableTime은 현재 시간표 계산 결과이므로 조회 후 필터링한다.
+     */
+    public ClassroomOverviewListResponseDto getClassroomOverviews(
+            Long userId,
+            Long buildingId,
+            Integer floorValue,
+            Boolean hasOutlet,
+            String availabilityStatus,
+            Integer minAvailableTime
+    ) {
+        List<Classroom> classrooms = classroomRepository.findClassroomsByFilters(
+                buildingId,
+                floorValue,
+                hasOutlet
+        );
+
+        List<Long> classroomIds = classrooms.stream()
+                .map(Classroom::getClassroomId)
+                .toList();
+
+        Set<Long> favoriteClassroomIds = getFavoriteClassroomIds(userId, classroomIds);
+
+        String today = getTodayValue();
+        LocalTime now = LocalTime.now();
+
+        List<Schedule> schedules = classroomIds.isEmpty()
+                ? List.of()
+                : scheduleRepository.findByClassroom_ClassroomIdInAndDayOfWeekOrderByStartTimeAsc(
+                        classroomIds,
+                        today
+                );
+
+        Map<Long, List<Schedule>> scheduleMap = schedules.stream()
+                .collect(Collectors.groupingBy(schedule -> schedule.getClassroom().getClassroomId()));
+
+        List<ClassroomOverviewListResponseDto.ClassroomOverviewDto> result = classrooms.stream()
+                .map(classroom -> {
+                    List<Schedule> classroomSchedules = scheduleMap.getOrDefault(
+                            classroom.getClassroomId(),
+                            List.of()
+                    );
+
+                    ClassroomAvailability availability = calculateAvailability(classroomSchedules, now);
+
+                    return ClassroomOverviewListResponseDto.ClassroomOverviewDto.builder()
+                            .classroomId(classroom.getClassroomId())
+                            .buildingName(classroom.getBuilding().getBuildingName())
+                            .roomName(classroom.getRoomName())
+                            .floorLabel(toFloorLabel(classroom.getFloor()))
+                            .hasOutlet(classroom.getHasOutlet())
+                            .isFavorite(favoriteClassroomIds.contains(classroom.getClassroomId()))
+                            .availabilityStatus(availability.status())
+                            .availableMinutes(availability.availableMinutes())
+                            .nextClassStartTime(formatTime(availability.nextClassStartTime()))
+                            .build();
+                })
+                .filter(dto -> matchesAvailabilityStatus(dto, availabilityStatus))
+                .filter(dto -> matchesMinAvailableTime(dto, minAvailableTime))
+                .toList();
+
+        return ClassroomOverviewListResponseDto.builder()
+                .classrooms(result)
+                .build();
+    }
+
+    /**
+     * 로그인 사용자가 즐겨찾기한 강의실 ID 목록을 조회한다.
+     */
+    private Set<Long> getFavoriteClassroomIds(Long userId, List<Long> classroomIds) {
+        if (classroomIds.isEmpty()) {
+            return Set.of();
+        }
+
+        return favoriteRepository.findByUser_UserIdAndClassroom_ClassroomIdIn(userId, classroomIds)
+                .stream()
+                .map(Favorite::getClassroom)
+                .map(Classroom::getClassroomId)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * 요청한 사용 상태 조건과 계산된 강의실 상태가 일치하는지 확인한다.
+     */
+    private boolean matchesAvailabilityStatus(
+            ClassroomOverviewListResponseDto.ClassroomOverviewDto dto,
+            String availabilityStatus
+    ) {
+        if (availabilityStatus == null || availabilityStatus.isBlank()) {
+            return true;
+        }
+
+        return availabilityStatus.trim().equals(dto.getAvailabilityStatus());
+    }
+
+    /**
+     * 요청한 최소 사용 가능 시간을 만족하는지 확인한다.
+     */
+    private boolean matchesMinAvailableTime(
+            ClassroomOverviewListResponseDto.ClassroomOverviewDto dto,
+            Integer minAvailableTime
+    ) {
+        if (minAvailableTime == null) {
+            return true;
+        }
+
+        return dto.getAvailableMinutes() >= minAvailableTime;
+    }
+
+    /**
+     * 현재 시각과 오늘 시간표를 비교해 강의실 사용 상태를 계산한다.
+     */
+    private ClassroomAvailability calculateAvailability(
+            List<Schedule> schedules,
+            LocalTime now
+    ) {
+        List<Schedule> sortedSchedules = schedules.stream()
+                .sorted(Comparator.comparing(Schedule::getStartTime))
+                .toList();
+
+        for (Schedule schedule : sortedSchedules) {
+            // 현재 수업 시간에 포함되면 사용 중으로 판단한다.
+            if (!now.isBefore(schedule.getStartTime()) && now.isBefore(schedule.getEndTime())) {
+                return new ClassroomAvailability(
+                        "IN_USE",
+                        0,
+                        null
+                );
+            }
+
+            // 다음 수업 시작 전이면 그때까지 사용 가능하다고 판단한다.
+            if (now.isBefore(schedule.getStartTime())) {
+                int availableMinutes = calculateMinutesBetween(now, schedule.getStartTime());
+
+                return new ClassroomAvailability(
+                        resolveAvailableStatus(availableMinutes),
+                        availableMinutes,
+                        schedule.getStartTime()
+                );
+            }
+        }
+
+        return new ClassroomAvailability(
+                "AVAILABLE_LONG",
+                calculateMinutesBetween(now, END_OF_DAY),
+                null
+        );
+    }
+
+    /**
+     * 사용 가능 시간이 기준값 이상이면 AVAILABLE_LONG, 미만이면 AVAILABLE_SHORT로 분류한다.
+     */
+    private String resolveAvailableStatus(int availableMinutes) {
+        if (availableMinutes >= AVAILABLE_LONG_THRESHOLD_MINUTES) {
+            return "AVAILABLE_LONG";
+        }
+
+        return "AVAILABLE_SHORT";
+    }
+
+    /**
+     * 두 시각 사이의 차이를 분 단위로 계산한다.
+     */
+    private int calculateMinutesBetween(LocalTime start, LocalTime end) {
+        return (int) Duration.between(start, end).toMinutes();
+    }
+
+    /**
+     * 오늘 요일을 시간표 테이블의 dayOfWeek 저장 형식에 맞게 변환한다.
+     */
+    private String getTodayValue() {
+        DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
+
+        return dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.ENGLISH).toUpperCase();
+    }
+
+    /**
+     * 층 숫자를 사용자 표시용 층 이름으로 변환한다.
+     */
+    private String toFloorLabel(Integer floor) {
+        if (floor == null) {
+            return null;
+        }
+
+        if (floor < 0) {
+            return "B" + Math.abs(floor);
+        }
+
+        return floor + "F";
+    }
+
+    /**
+     * LocalTime을 HH:mm 형식의 문자열로 변환한다.
+     */
+    private String formatTime(LocalTime time) {
+        if (time == null) {
+            return null;
+        }
+
+        return time.format(TIME_FORMATTER);
+    }
+
+    /**
+     * 강의실 사용 상태 계산 결과를 담는 내부 값 객체.
+     */
+    private record ClassroomAvailability(
+            String status,
+            Integer availableMinutes,
+            LocalTime nextClassStartTime
+    ) {
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/tag/entity/Tag.java
+++ b/src/main/java/com/dku/emptybear/domain/tag/entity/Tag.java
@@ -1,0 +1,24 @@
+package com.dku.emptybear.domain.tag.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tag_id")
+    private Long tagId;
+
+    @Column(name = "code", nullable = false, unique = true, length = 50)
+    private String code;
+
+    @Column(name = "display_name", nullable = false, length = 100)
+    private String displayName;
+}


### PR DESCRIPTION
## 📝 개요 (Overview)
- 강의실 개요 목록 조회, 강의실 상세 정보 조회, 강의실 주간 시간표 조회 API를 구현했습니다.
- 강의실 조건 필터링, 현재 사용 가능 상태 계산, 즐겨찾기 여부, 리뷰 요약, 주간 시간표 조회 기능을 제공합니다.

## 📌 이슈 번호 작성 (Related Issue)
- Closes #15 

## 🤔 작업 배경 및 목적 (Why)
- 사용자가 조건에 맞는 강의실을 탐색하고, 특정 강의실의 상세 정보와 시간표를 확인할 수 있도록 하기 위해 구현했습니다.
- 건물, 층, 콘센트 여부, 사용 가능 상태, 최소 사용 가능 시간 등의 조건을 기반으로 강의실 목록을 조회할 필요가 있습니다.
- 강의실 상세 화면에서 현재 사용 상태, 즐겨찾기 여부, 리뷰 태그 요약 정보를 제공하기 위해 관련 조회 로직을 추가했습니다.
- 특정 강의실의 주간 시간표를 확인할 수 있도록 시간표 조회 API를 구현했습니다.

## 🏷️ PR 유형 (Type of PR)
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 사용자 UI 디자인 변경
- [ ] ♻️ 코드 리팩토링
- [ ] 📝 문서 수정 (Wiki, README 등)
- [ ] ✅ 테스트 추가 및 리팩토링
- [x] 📁 파일 혹은 폴더 구조 수정 및 삭제

## 🛠️ 주요 변경 사항 (What)
- `GET /api/classrooms`
  - 강의실 개요 목록 조회 API를 구현했습니다.
  - `buildingId`, `floorValue`, `hasOutlet`, `availabilityStatus`, `minAvailableTime` 조건 필터를 지원합니다.
  - 로그인 사용자의 즐겨찾기 여부를 `isFavorite`로 반환합니다.
  - 현재 시각과 시간표를 기준으로 `IN_USE`, `AVAILABLE_SHORT`, `AVAILABLE_LONG` 상태를 계산합니다.

- `GET /api/classrooms/{classroomId}`
  - 강의실 상세 정보 조회 API를 구현했습니다.
  - 강의실 기본 정보, 건물 정보, 층 정보, 콘센트 여부, 즐겨찾기 여부, 현재 사용 상태를 반환합니다.
  - 리뷰 전체 개수와 태그별 리뷰 개수를 포함한 `reviewSummary`를 반환합니다.

- `GET /api/classrooms/{classroomId}/schedule`
  - 특정 강의실의 주간 시간표 조회 API를 구현했습니다.
  - 시간표가 없는 경우 `weeklySchedule: []` 형태로 반환합니다.
  - 요일 문자열 기준 정렬 문제를 피하기 위해 Service에서 `MON`~`SUN` 순서로 정렬하도록 처리했습니다.

- `classroom`, `schedule`, `favorite`, `review`, `review_tag` 관련 Entity 및 Repository를 추가 또는 수정했습니다.
- `Tag`는 별도 `tag` 도메인에 유지하고, `ReviewTag`에서 `domain.tag.entity.Tag`를 참조하도록 구성했습니다.
- Swagger 문서화를 위해 각 API에 `@Operation`, `@Parameter`, `@SecurityRequirement(name = "bearerAuth")`를 적용했습니다.

## 📸 스크린 샷 (Optional) 
-

## ✅ 체크리스트
- [x] 불필요한 주석/코드 및 디버깅용 로그 제거
- [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 단위 테스트 등)
- [x] 시뮬레이터 또는 실제 기기에서 정상 동작하는지 확인
- [x] 커밋 메시지 컨벤션을 준수 (*Commit message convention 참고)
- [x] 관련 이슈를 닫는 커밋 메시지 사용 (Closes #)
- [x] PR 제목과 내용 명확히 작성

## 💬 리뷰 포인트 (To Reviewers)
- 강의실 사용 상태 계산 기준이 적절한지 확인 부탁드립니다.
  - 현재 수업 중이면 `IN_USE`
  - 다음 수업까지 30분 이상 남으면 `AVAILABLE_LONG`
  - 다음 수업까지 30분 미만이면 `AVAILABLE_SHORT`
- `availabilityStatus`, `minAvailableTime`은 시간표 기반 계산 결과이므로 DB 조회 이후 Service에서 후처리 필터링하도록 구현했습니다. 이 방식이 적절한지 확인 부탁드립니다.
- `schedule.dayOfWeek` 값이 `MON`, `TUE`, `WED`, `THU`, `FRI`, `SAT`, `SUN` 형식이라는 전제로 구현했습니다.
- `Tag`는 별도 도메인으로 유지하고, `ReviewTag`에서 참조하는 구조로 구현했습니다. 현재 도메인 분리 방식이 적절한지 확인 부탁드립니다.