### PR TITLE
feat: 리뷰 태그 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/dku/emptybear/domain/tag/controller/TagController.java
+++ b/src/main/java/com/dku/emptybear/domain/tag/controller/TagController.java
@@ -1,0 +1,28 @@
+package com.dku.emptybear.domain.tag.controller;
+
+import com.dku.emptybear.domain.tag.dto.response.ReviewTagListResponseDto;
+import com.dku.emptybear.domain.tag.service.TagService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Tags", description = "태그 관련 API")
+@RestController
+@RequestMapping("/api/tags")
+@RequiredArgsConstructor
+public class TagController {
+
+    private final TagService tagService;
+
+    @Operation(
+            summary = "리뷰 태그 목록 조회",
+            description = "강의실 리뷰 작성 시 선택 가능한 태그 목록을 조회합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/reviews")
+    public ReviewTagListResponseDto getReviewTags() {
+        return tagService.getReviewTags();
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/tag/dto/response/ReviewTagListResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/tag/dto/response/ReviewTagListResponseDto.java
@@ -1,0 +1,44 @@
+package com.dku.emptybear.domain.tag.dto.response;
+
+import com.dku.emptybear.domain.tag.entity.Tag;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ReviewTagListResponseDto {
+
+    @Schema(description = "리뷰 태그 목록")
+    private List<ReviewTagInfoDto> tags;
+
+    @Getter
+    @Builder
+    public static class ReviewTagInfoDto {
+
+        @Schema(description = "태그 고유 ID", example = "1")
+        private Long tagId;
+
+        @Schema(description = "태그 내부 코드값", example = "QUIET")
+        private String code;
+
+        @Schema(description = "사용자 표시용 태그명", example = "조용해요")
+        private String displayName;
+    }
+
+    public static ReviewTagListResponseDto from(List<Tag> tags) {
+        return ReviewTagListResponseDto.builder()
+                .tags(
+                        tags.stream()
+                                .map(tag -> ReviewTagInfoDto.builder()
+                                        .tagId(tag.getTagId())
+                                        .code(tag.getCode())
+                                        .displayName(tag.getDisplayName())
+                                        .build())
+                                .toList()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/tag/repository/TagRepository.java
@@ -1,0 +1,11 @@
+package com.dku.emptybear.domain.tag.repository;
+
+import com.dku.emptybear.domain.tag.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    List<Tag> findAllByOrderByTagIdAsc();
+}

--- a/src/main/java/com/dku/emptybear/domain/tag/service/TagService.java
+++ b/src/main/java/com/dku/emptybear/domain/tag/service/TagService.java
@@ -1,0 +1,27 @@
+package com.dku.emptybear.domain.tag.service;
+
+import com.dku.emptybear.domain.tag.dto.response.ReviewTagListResponseDto;
+import com.dku.emptybear.domain.tag.entity.Tag;
+import com.dku.emptybear.domain.tag.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    /**
+     * 리뷰 작성 시 선택 가능한 태그 목록을 조회한다.
+     */
+    public ReviewTagListResponseDto getReviewTags() {
+        List<Tag> tags = tagRepository.findAllByOrderByTagIdAsc();
+
+        return ReviewTagListResponseDto.from(tags);
+    }
+}


### PR DESCRIPTION
## 📝 개요 (Overview)
- 리뷰 작성 시 선택 가능한 태그 목록을 조회하는 API를 구현했습니다.
- `tags` 도메인을 분리하여 태그 관련 Controller, Service, Repository, DTO, Entity 구조를 구성했습니다.

## 📌 이슈 번호 작성 (Related Issue)
- Closes #17 

## 🤔 작업 배경 및 목적 (Why)
- 강의실 리뷰 작성 화면에서 사용자가 선택할 수 있는 리뷰 태그 목록이 필요합니다.
- 리뷰 태그는 여러 리뷰에서 공통으로 사용되는 고정 데이터이므로 별도의 `tag` 도메인으로 분리하여 관리하도록 구현했습니다.
- 프론트엔드에서 리뷰 작성 폼을 구성할 때 태그 ID, 내부 코드값, 사용자 표시명을 함께 조회할 수 있도록 API를 제공합니다.

## 🏷️ PR 유형 (Type of PR)
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 사용자 UI 디자인 변경
- [ ] ♻️ 코드 리팩토링
- [ ] 📝 문서 수정 (Wiki, README 등)
- [ ] ✅ 테스트 추가 및 리팩토링
- [x] 📁 파일 혹은 폴더 구조 수정 및 삭제

## 🛠️ 주요 변경 사항 (What)
- `GET /api/tags/reviews`
  - 리뷰 작성 시 선택 가능한 태그 목록 조회 API를 구현했습니다.
  - 태그 고유 ID, 내부 코드값, 사용자 표시용 태그명을 반환합니다.

- `Tag` 도메인 구조를 추가했습니다.
  - `TagController`
  - `TagService`
  - `TagRepository`
  - `Tag` Entity
  - `ReviewTagListResponseDto`

- 태그 목록은 `tagId` 오름차순으로 조회되도록 구현했습니다.
- Swagger 문서화를 위해 `@Operation`, `@SecurityRequirement(name = "bearerAuth")`를 적용했습니다.
- 사용자별 응답 값은 없지만, 서비스 접근 정책에 맞춰 인증 필요 API로 문서화했습니다.

## 📸 스크린 샷 (Optional) 
-

## ✅ 체크리스트
- [x] 불필요한 주석/코드 및 디버깅용 로그 제거
- [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 단위 테스트 등)
- [x] 시뮬레이터 또는 실제 기기에서 정상 동작하는지 확인
- [x] 커밋 메시지 컨벤션을 준수 (*Commit message convention 참고)
- [x] 관련 이슈를 닫는 커밋 메시지 사용 (Closes #)
- [x] PR 제목과 내용 명확히 작성

## 💬 리뷰 포인트 (To Reviewers)
- 리뷰 태그를 `classroom` 도메인이 아닌 별도 `tag` 도메인으로 분리한 구조가 적절한지 확인 부탁드립니다.
- 태그 목록 정렬 기준을 `tagId` 오름차순으로 두는 것이 적절한지 확인 부탁드립니다.
- 해당 API는 로그인 사용자별 데이터는 사용하지 않지만, 서비스 정책상 인증 필요 API로 분류했습니다. 이 정책이 적절한지 확인 부탁드립니다.