### PR TITLE
feat: 강의실 리뷰 작성, 조회 및 삭제 API 구현

### DIFF
--- a/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
@@ -5,6 +5,7 @@ import com.dku.emptybear.domain.classroom.dto.response.ClassroomDetailResponseDt
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomOverviewListResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomWeeklyScheduleResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.CreateReviewResponseDto;
+import com.dku.emptybear.domain.classroom.dto.response.ClassroomReviewListResponseDto;
 import com.dku.emptybear.domain.classroom.service.ClassroomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -107,5 +108,25 @@ public class ClassroomController {
         Long userId = Long.valueOf(authentication.getName());
 
         return classroomService.createReview(userId, classroomId, request);
+    }
+
+    @Operation(
+            summary = "강의실 리뷰 조회",
+            description = "특정 강의실에 작성된 리뷰 목록을 조회합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/{classroomId}/reviews")
+    public ClassroomReviewListResponseDto getClassroomReviews(
+            Authentication authentication,
+
+            @Parameter(description = "리뷰 목록을 조회할 강의실 ID", example = "12")
+            @PathVariable Long classroomId,
+
+            @Parameter(description = "조회할 리뷰 개수", example = "10")
+            @RequestParam(required = false) Integer limit
+    ) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return classroomService.getClassroomReviews(userId, classroomId, limit);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpStatus;
 
 import jakarta.validation.Valid;
 
@@ -97,6 +98,7 @@ public class ClassroomController {
             description = "로그인한 사용자가 특정 강의실에 선택형 태그 기반 리뷰를 작성합니다."
     )
     @SecurityRequirement(name = "bearerAuth")
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{classroomId}/reviews")
     public CreateReviewResponseDto createReview(
             Authentication authentication,

--- a/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
@@ -6,6 +6,7 @@ import com.dku.emptybear.domain.classroom.dto.response.ClassroomOverviewListResp
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomWeeklyScheduleResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.CreateReviewResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomReviewListResponseDto;
+import com.dku.emptybear.domain.classroom.dto.response.DeleteReviewResponseDto;
 import com.dku.emptybear.domain.classroom.service.ClassroomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -128,5 +129,25 @@ public class ClassroomController {
         Long userId = Long.valueOf(authentication.getName());
 
         return classroomService.getClassroomReviews(userId, classroomId, limit);
+    }
+
+    @Operation(
+            summary = "강의실 리뷰 삭제",
+            description = "로그인한 사용자가 자신이 작성한 특정 강의실 리뷰를 삭제합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @DeleteMapping("/{classroomId}/reviews/{reviewId}")
+    public DeleteReviewResponseDto deleteReview(
+            Authentication authentication,
+
+            @Parameter(description = "리뷰가 속한 강의실 ID", example = "12")
+            @PathVariable Long classroomId,
+
+            @Parameter(description = "삭제할 리뷰 ID", example = "31")
+            @PathVariable Long reviewId
+    ) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return classroomService.deleteReview(userId, classroomId, reviewId);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
@@ -1,8 +1,10 @@
 package com.dku.emptybear.domain.classroom.controller;
 
+import com.dku.emptybear.domain.classroom.dto.request.CreateReviewRequestDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomDetailResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomOverviewListResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomWeeklyScheduleResponseDto;
+import com.dku.emptybear.domain.classroom.dto.response.CreateReviewResponseDto;
 import com.dku.emptybear.domain.classroom.service.ClassroomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,6 +13,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
 
 @Tag(name = "Classrooms", description = "강의실 관련 API")
 @RestController
@@ -84,5 +88,24 @@ public class ClassroomController {
             @PathVariable Long classroomId
     ) {
         return classroomService.getWeeklySchedule(classroomId);
+    }
+
+    @Operation(
+            summary = "강의실 리뷰 작성",
+            description = "로그인한 사용자가 특정 강의실에 선택형 태그 기반 리뷰를 작성합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/{classroomId}/reviews")
+    public CreateReviewResponseDto createReview(
+            Authentication authentication,
+
+            @Parameter(description = "리뷰를 작성할 강의실 ID", example = "12")
+            @PathVariable Long classroomId,
+
+            @Valid @RequestBody CreateReviewRequestDto request
+    ) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return classroomService.createReview(userId, classroomId, request);
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/dto/request/CreateReviewRequestDto.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/dto/request/CreateReviewRequestDto.java
@@ -1,0 +1,15 @@
+package com.dku.emptybear.domain.classroom.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CreateReviewRequestDto {
+
+    @Schema(description = "리뷰에 선택한 태그 ID 목록", example = "[1, 2]")
+    @NotEmpty(message = "태그를 1개 이상 선택해야 합니다.")
+    private List<Long> tagIds;
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/dto/response/ClassroomReviewListResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/dto/response/ClassroomReviewListResponseDto.java
@@ -1,0 +1,64 @@
+package com.dku.emptybear.domain.classroom.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class ClassroomReviewListResponseDto {
+
+    @Schema(description = "강의실 고유 ID", example = "12")
+    private Long classroomId;
+
+    @Schema(description = "로그인 사용자가 해당 강의실에 작성한 리뷰 ID", example = "31", nullable = true)
+    private Long myReviewId;
+
+    @Schema(description = "리뷰 목록")
+    private List<ReviewInfoDto> reviews;
+
+    @Getter
+    @Builder
+    public static class ReviewInfoDto {
+
+        @Schema(description = "리뷰 고유 ID", example = "31")
+        private Long reviewId;
+
+        @Schema(description = "리뷰 작성자 정보")
+        private ReviewUserDto user;
+
+        @Schema(description = "리뷰에 선택된 태그 목록")
+        private List<ReviewTagDto> tags;
+
+        @Schema(description = "리뷰 작성 시각", example = "2026-04-10T14:30:00")
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    public static class ReviewUserDto {
+
+        @Schema(description = "리뷰 작성자 고유 ID", example = "1")
+        private Long userId;
+
+        @Schema(description = "리뷰 작성자 닉네임", example = "비었곰")
+        private String nickname;
+    }
+
+    @Getter
+    @Builder
+    public static class ReviewTagDto {
+
+        @Schema(description = "태그 ID", example = "1")
+        private Long tagId;
+
+        @Schema(description = "태그 내부 코드값", example = "QUIET")
+        private String code;
+
+        @Schema(description = "태그 표시명", example = "조용해요")
+        private String displayName;
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/dto/response/CreateReviewResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/dto/response/CreateReviewResponseDto.java
@@ -1,0 +1,16 @@
+package com.dku.emptybear.domain.classroom.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateReviewResponseDto {
+
+    @Schema(description = "생성된 리뷰 고유 ID", example = "31")
+    private Long reviewId;
+
+    @Schema(description = "리뷰 작성 결과 메시지", example = "리뷰가 등록되었습니다.")
+    private String message;
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/dto/response/DeleteReviewResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/dto/response/DeleteReviewResponseDto.java
@@ -1,0 +1,16 @@
+package com.dku.emptybear.domain.classroom.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeleteReviewResponseDto {
+
+    @Schema(description = "삭제된 리뷰 ID", example = "31")
+    private Long reviewId;
+
+    @Schema(description = "리뷰가 속한 강의실 ID", example = "12")
+    private Long classroomId;
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/entity/Review.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/entity/Review.java
@@ -9,7 +9,13 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "review")
+@Table(
+        name = "review",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_review_user_classroom",
+                columnNames = {"user_id", "classroom_id"}
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review {
@@ -32,6 +38,15 @@ public class Review {
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    private Review(User user, Classroom classroom) {
+        this.user = user;
+        this.classroom = classroom;
+    }
+
+    public static Review create(User user, Classroom classroom) {
+        return new Review(user, classroom);
+    }
 
     @PrePersist
     public void prePersist() {

--- a/src/main/java/com/dku/emptybear/domain/classroom/entity/ReviewTag.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/entity/ReviewTag.java
@@ -30,4 +30,13 @@ public class ReviewTag {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id", nullable = false)
     private Tag tag;
+
+    private ReviewTag(Review review, Tag tag) {
+        this.review = review;
+        this.tag = tag;
+    }
+
+    public static ReviewTag create(Review review, Tag tag) {
+        return new ReviewTag(review, tag);
+    }
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewRepository.java
@@ -1,7 +1,13 @@
 package com.dku.emptybear.domain.classroom.repository;
 
 import com.dku.emptybear.domain.classroom.entity.Review;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
@@ -10,5 +16,22 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     boolean existsByUser_UserIdAndClassroom_ClassroomId(
             Long userId,
             Long classroomId
+    );
+
+    Optional<Review> findByUser_UserIdAndClassroom_ClassroomId(
+            Long userId,
+            Long classroomId
+    );
+
+    @Query("""
+            SELECT r
+            FROM Review r
+            JOIN FETCH r.user u
+            WHERE r.classroom.classroomId = :classroomId
+            ORDER BY r.createdAt DESC
+            """)
+    List<Review> findReviewsByClassroomId(
+            @Param("classroomId") Long classroomId,
+            Pageable pageable
     );
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewRepository.java
@@ -23,6 +23,12 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             Long classroomId
     );
 
+    Optional<Review> findByReviewIdAndClassroom_ClassroomIdAndUser_UserId(
+            Long reviewId,
+            Long classroomId,
+            Long userId
+    );
+
     @Query("""
             SELECT r
             FROM Review r

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewRepository.java
@@ -34,7 +34,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             FROM Review r
             JOIN FETCH r.user u
             WHERE r.classroom.classroomId = :classroomId
-            ORDER BY r.createdAt DESC
+            ORDER BY r.createdAt DESC, r.reviewId DESC
             """)
     List<Review> findReviewsByClassroomId(
             @Param("classroomId") Long classroomId,

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewRepository.java
@@ -6,4 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     long countByClassroom_ClassroomId(Long classroomId);
+
+    boolean existsByUser_UserIdAndClassroom_ClassroomId(
+            Long userId,
+            Long classroomId
+    );
 }

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewTagRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewTagRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
@@ -23,6 +24,16 @@ public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
             ORDER BY COUNT(rt.reviewTagId) DESC, t.tagId ASC
             """)
     List<TagCountProjection> countTagsByClassroomId(@Param("classroomId") Long classroomId);
+
+    @Query("""
+            SELECT rt
+            FROM ReviewTag rt
+            JOIN FETCH rt.review r
+            JOIN FETCH rt.tag t
+            WHERE r.reviewId IN :reviewIds
+            ORDER BY r.reviewId ASC, t.tagId ASC
+            """)
+    List<ReviewTag> findByReviewIdsWithTag(@Param("reviewIds") Collection<Long> reviewIds);
 
     interface TagCountProjection {
 

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewTagRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ReviewTagRepository.java
@@ -35,6 +35,8 @@ public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
             """)
     List<ReviewTag> findByReviewIdsWithTag(@Param("reviewIds") Collection<Long> reviewIds);
 
+    void deleteByReview_ReviewId(Long reviewId);
+
     interface TagCountProjection {
 
         Long getTagId();

--- a/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
@@ -5,6 +5,7 @@ import com.dku.emptybear.domain.classroom.dto.response.ClassroomDetailResponseDt
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomOverviewListResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomWeeklyScheduleResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.CreateReviewResponseDto;
+import com.dku.emptybear.domain.classroom.dto.response.ClassroomReviewListResponseDto;
 import com.dku.emptybear.domain.classroom.entity.Classroom;
 import com.dku.emptybear.domain.classroom.entity.Favorite;
 import com.dku.emptybear.domain.classroom.entity.Schedule;
@@ -25,6 +26,8 @@ import com.dku.emptybear.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.DayOfWeek;
 import java.time.Duration;
@@ -39,6 +42,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -261,6 +265,99 @@ public class ClassroomService {
                 .reviewId(review.getReviewId())
                 .message("리뷰가 등록되었습니다.")
                 .build();
+    }
+
+    /**
+     * 특정 강의실에 작성된 리뷰 목록과 로그인 사용자의 리뷰 ID를 조회한다.
+     */
+    public ClassroomReviewListResponseDto getClassroomReviews(
+            Long userId,
+            Long classroomId,
+            Integer limit
+    ) {
+        classroomRepository.findById(classroomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의실입니다."));
+
+        int reviewLimit = resolveReviewLimit(limit);
+
+        Pageable pageable = PageRequest.of(0, reviewLimit);
+
+        List<Review> reviews = reviewRepository.findReviewsByClassroomId(classroomId, pageable);
+
+        Optional<Review> myReview = reviewRepository.findByUser_UserIdAndClassroom_ClassroomId(
+                userId,
+                classroomId
+        );
+
+        List<Long> reviewIds = reviews.stream()
+                .map(Review::getReviewId)
+                .toList();
+
+        Map<Long, List<ReviewTag>> reviewTagMap = getReviewTagMap(reviewIds);
+
+        List<ClassroomReviewListResponseDto.ReviewInfoDto> reviewDtos = reviews.stream()
+                .map(review -> ClassroomReviewListResponseDto.ReviewInfoDto.builder()
+                        .reviewId(review.getReviewId())
+                        .user(ClassroomReviewListResponseDto.ReviewUserDto.builder()
+                                .userId(review.getUser().getUserId())
+                                .nickname(review.getUser().getNickname())
+                                .build())
+                        .tags(toReviewTagDtos(reviewTagMap.getOrDefault(
+                                review.getReviewId(),
+                                List.of()
+                        )))
+                        .createdAt(review.getCreatedAt())
+                        .build())
+                .toList();
+
+        return ClassroomReviewListResponseDto.builder()
+                .classroomId(classroomId)
+                .myReviewId(myReview.map(Review::getReviewId).orElse(null))
+                .reviews(reviewDtos)
+                .build();
+    }
+
+    /**
+     * limit 값이 없거나 유효하지 않은 경우 기본 조회 개수를 사용한다.
+     */
+    private int resolveReviewLimit(Integer limit) {
+        if (limit == null) {
+            return 10;
+        }
+
+        if (limit <= 0) {
+            throw new IllegalArgumentException("limit은 1 이상이어야 합니다.");
+        }
+
+        return limit;
+    }
+
+    /**
+     * 리뷰 ID 목록에 해당하는 태그들을 reviewId 기준으로 묶는다.
+     */
+    private Map<Long, List<ReviewTag>> getReviewTagMap(List<Long> reviewIds) {
+        if (reviewIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return reviewTagRepository.findByReviewIdsWithTag(reviewIds)
+                .stream()
+                .collect(Collectors.groupingBy(reviewTag -> reviewTag.getReview().getReviewId()));
+    }
+
+    /**
+     * ReviewTag 엔티티 목록을 리뷰 응답용 태그 DTO로 변환한다.
+     */
+    private List<ClassroomReviewListResponseDto.ReviewTagDto> toReviewTagDtos(
+            List<ReviewTag> reviewTags
+    ) {
+        return reviewTags.stream()
+                .map(reviewTag -> ClassroomReviewListResponseDto.ReviewTagDto.builder()
+                        .tagId(reviewTag.getTag().getTagId())
+                        .code(reviewTag.getTag().getCode())
+                        .displayName(reviewTag.getTag().getDisplayName())
+                        .build())
+                .toList();
     }
 
     /**

--- a/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
@@ -6,6 +6,7 @@ import com.dku.emptybear.domain.classroom.dto.response.ClassroomOverviewListResp
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomWeeklyScheduleResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.CreateReviewResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomReviewListResponseDto;
+import com.dku.emptybear.domain.classroom.dto.response.DeleteReviewResponseDto;
 import com.dku.emptybear.domain.classroom.entity.Classroom;
 import com.dku.emptybear.domain.classroom.entity.Favorite;
 import com.dku.emptybear.domain.classroom.entity.Schedule;
@@ -314,6 +315,32 @@ public class ClassroomService {
                 .classroomId(classroomId)
                 .myReviewId(myReview.map(Review::getReviewId).orElse(null))
                 .reviews(reviewDtos)
+                .build();
+    }
+    
+    /**
+     * 로그인 사용자가 자신이 작성한 강의실 리뷰를 삭제한다.
+     */
+    @Transactional
+    public DeleteReviewResponseDto deleteReview(
+            Long userId,
+            Long classroomId,
+            Long reviewId
+    ) {
+        Review review = reviewRepository.findByReviewIdAndClassroom_ClassroomIdAndUser_UserId(
+                reviewId,
+                classroomId,
+                userId
+        ).orElseThrow(() -> new IllegalArgumentException("삭제할 수 있는 리뷰가 존재하지 않습니다."));
+
+        // review_tag가 review를 참조하므로 매핑 데이터를 먼저 삭제한다.
+        reviewTagRepository.deleteByReview_ReviewId(reviewId);
+
+        reviewRepository.delete(review);
+
+        return DeleteReviewResponseDto.builder()
+                .reviewId(reviewId)
+                .classroomId(classroomId)
                 .build();
     }
 

--- a/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.DayOfWeek;
 import java.time.Duration;
@@ -53,6 +54,8 @@ public class ClassroomService {
     private static final int AVAILABLE_LONG_THRESHOLD_MINUTES = 30;
     private static final LocalTime END_OF_DAY = LocalTime.of(23, 59);
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+    private static final int DEFAULT_REVIEW_LIMIT = 10;
+    private static final int MAX_REVIEW_LIMIT = 50;
 
     private final ClassroomRepository classroomRepository;
     private final ScheduleRepository scheduleRepository;
@@ -254,7 +257,13 @@ public class ClassroomService {
             throw new IllegalArgumentException("존재하지 않는 태그가 포함되어 있습니다.");
         }
 
-        Review review = reviewRepository.save(Review.create(user, classroom));
+        Review review;
+
+        try {
+            review = reviewRepository.saveAndFlush(Review.create(user, classroom));
+        } catch (DataIntegrityViolationException e) {
+            throw new IllegalArgumentException("이미 해당 강의실에 리뷰를 작성했습니다.");
+        }
 
         List<ReviewTag> reviewTags = tags.stream()
                 .map(tag -> ReviewTag.create(review, tag))
@@ -345,15 +354,19 @@ public class ClassroomService {
     }
 
     /**
-     * limit 값이 없거나 유효하지 않은 경우 기본 조회 개수를 사용한다.
+     * limit 값이 없으면 기본 조회 개수를 사용하고, 0 이하 또는 최대값 초과이면 예외를 발생시킨다.
      */
     private int resolveReviewLimit(Integer limit) {
         if (limit == null) {
-            return 10;
+            return DEFAULT_REVIEW_LIMIT;
         }
 
         if (limit <= 0) {
             throw new IllegalArgumentException("limit은 1 이상이어야 합니다.");
+        }
+
+        if (limit > MAX_REVIEW_LIMIT) {
+            throw new IllegalArgumentException("limit은 최대 " + MAX_REVIEW_LIMIT + "까지 가능합니다.");
         }
 
         return limit;

--- a/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
@@ -1,16 +1,27 @@
 package com.dku.emptybear.domain.classroom.service;
 
+import com.dku.emptybear.domain.classroom.dto.request.CreateReviewRequestDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomDetailResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomOverviewListResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomWeeklyScheduleResponseDto;
+import com.dku.emptybear.domain.classroom.dto.response.CreateReviewResponseDto;
 import com.dku.emptybear.domain.classroom.entity.Classroom;
 import com.dku.emptybear.domain.classroom.entity.Favorite;
 import com.dku.emptybear.domain.classroom.entity.Schedule;
+import com.dku.emptybear.domain.classroom.entity.Review;
+import com.dku.emptybear.domain.classroom.entity.ReviewTag;
 import com.dku.emptybear.domain.classroom.repository.ClassroomRepository;
 import com.dku.emptybear.domain.classroom.repository.FavoriteRepository;
 import com.dku.emptybear.domain.classroom.repository.ReviewRepository;
 import com.dku.emptybear.domain.classroom.repository.ReviewTagRepository;
 import com.dku.emptybear.domain.classroom.repository.ScheduleRepository;
+
+import com.dku.emptybear.domain.tag.entity.Tag;
+import com.dku.emptybear.domain.tag.repository.TagRepository;
+
+import com.dku.emptybear.domain.user.entity.User;
+import com.dku.emptybear.domain.user.repository.UserRepository;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +38,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.LinkedHashSet;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +54,8 @@ public class ClassroomService {
     private final FavoriteRepository favoriteRepository;
     private final ReviewRepository reviewRepository;
     private final ReviewTagRepository reviewTagRepository;
+    private final UserRepository userRepository;
+    private final TagRepository tagRepository;
 
     /**
      * 조건에 맞는 강의실 개요 목록을 조회한다.
@@ -195,6 +209,71 @@ public class ClassroomService {
                 .classroomId(classroomId)
                 .weeklySchedule(weeklySchedule)
                 .build();
+    }
+
+    /**
+     * 로그인 사용자가 특정 강의실에 태그 기반 리뷰를 작성한다.
+     */
+    @Transactional
+    public CreateReviewResponseDto createReview(
+            Long userId,
+            Long classroomId,
+            CreateReviewRequestDto request
+    ) {
+        validateTagIds(request.getTagIds());
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        Classroom classroom = classroomRepository.findById(classroomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의실입니다."));
+
+        if (reviewRepository.existsByUser_UserIdAndClassroom_ClassroomId(userId, classroomId)) {
+            throw new IllegalArgumentException("이미 해당 강의실에 리뷰를 작성했습니다.");
+        }
+
+        List<Long> distinctTagIds = request.getTagIds().stream()
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toCollection(LinkedHashSet::new),
+                        List::copyOf
+                ));
+
+        // 중복 태그 ID가 들어오면 review_tag 중복 매핑을 방지하기 위해 요청을 거절한다.
+        if (distinctTagIds.size() != request.getTagIds().size()) {
+            throw new IllegalArgumentException("중복된 태그가 포함되어 있습니다.");
+        }
+
+        List<Tag> tags = tagRepository.findAllById(distinctTagIds);
+
+        if (tags.size() != distinctTagIds.size()) {
+            throw new IllegalArgumentException("존재하지 않는 태그가 포함되어 있습니다.");
+        }
+
+        Review review = reviewRepository.save(Review.create(user, classroom));
+
+        List<ReviewTag> reviewTags = tags.stream()
+                .map(tag -> ReviewTag.create(review, tag))
+                .toList();
+
+        reviewTagRepository.saveAll(reviewTags);
+
+        return CreateReviewResponseDto.builder()
+                .reviewId(review.getReviewId())
+                .message("리뷰가 등록되었습니다.")
+                .build();
+    }
+
+    /**
+     * 리뷰 작성 요청의 태그 ID 목록을 검증한다.
+     */
+    private void validateTagIds(List<Long> tagIds) {
+        if (tagIds == null || tagIds.isEmpty()) {
+            throw new IllegalArgumentException("태그를 1개 이상 선택해야 합니다.");
+        }
+
+        if (tagIds.stream().anyMatch(tagId -> tagId == null || tagId <= 0)) {
+            throw new IllegalArgumentException("유효하지 않은 태그 ID가 포함되어 있습니다.");
+        }
     }
 
     /**


### PR DESCRIPTION
## 📝 개요 (Overview)
- 강의실 리뷰 작성, 리뷰 목록 조회, 리뷰 삭제 API를 구현했습니다.
- 로그인 사용자가 특정 강의실에 태그 기반 리뷰를 작성하고, 강의실별 리뷰 목록을 조회하며, 자신이 작성한 리뷰를 삭제할 수 있도록 구현했습니다.

## 📌 이슈 번호 작성 (Related Issue)
- Closes #19 

## 🤔 작업 배경 및 목적 (Why)
- 사용자가 강의실에 대한 후기를 선택형 태그 기반으로 남길 수 있도록 리뷰 작성 기능이 필요합니다.
- 강의실 상세 화면에서 다른 사용자가 작성한 리뷰와 태그 정보를 확인할 수 있도록 리뷰 목록 조회 API를 구현했습니다.
- 사용자가 자신이 작성한 리뷰를 삭제할 수 있도록 삭제 API를 추가했습니다.
- 리뷰 태그 기반 데이터를 저장하고 조회하기 위해 `review`, `review_tag`, `tag` 연관 구조를 활용했습니다.

## 🏷️ PR 유형 (Type of PR)
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 사용자 UI 디자인 변경
- [ ] ♻️ 코드 리팩토링
- [ ] 📝 문서 수정 (Wiki, README 등)
- [ ] ✅ 테스트 추가 및 리팩토링
- [x] 📁 파일 혹은 폴더 구조 수정 및 삭제

## 🛠️ 주요 변경 사항 (What)
- `POST /api/classrooms/{classroomId}/reviews`
  - 로그인 사용자가 특정 강의실에 태그 기반 리뷰를 작성하는 API를 구현했습니다.
  - 요청으로 전달된 `tagIds`를 검증하고, 존재하는 태그만 리뷰에 매핑되도록 처리했습니다.
  - 동일 사용자가 같은 강의실에 리뷰를 중복 작성하지 못하도록 검증했습니다.
  - 리뷰 생성 후 `reviewId`와 등록 완료 메시지를 반환합니다.

- `GET /api/classrooms/{classroomId}/reviews`
  - 특정 강의실에 작성된 리뷰 목록 조회 API를 구현했습니다.
  - `limit` query parameter를 통해 조회 개수를 제한할 수 있도록 구현했습니다.
  - 리뷰 작성자 정보, 리뷰별 태그 목록, 작성 시각을 반환합니다.
  - 로그인 사용자가 해당 강의실에 작성한 리뷰가 있는 경우 `myReviewId`를 함께 반환합니다.

- `DELETE /api/classrooms/{classroomId}/reviews/{reviewId}`
  - 로그인 사용자가 자신이 작성한 특정 강의실 리뷰를 삭제하는 API를 구현했습니다.
  - `reviewId`, `classroomId`, `userId`를 함께 검증하여 다른 사용자의 리뷰 삭제를 방지했습니다.
  - `review_tag` 매핑 데이터를 먼저 삭제한 뒤 리뷰를 삭제하도록 처리했습니다.
  - 삭제된 `reviewId`와 `classroomId`를 반환합니다.

- 리뷰 작성 요청/응답, 리뷰 목록 응답, 리뷰 삭제 응답 DTO를 추가했습니다.
- `Review`, `ReviewTag` 엔티티에 리뷰 생성과 태그 매핑 생성을 위한 정적 팩토리 메서드를 추가했습니다.
- 리뷰 중복 방지를 위해 `(user_id, classroom_id)` 조합에 unique constraint를 적용했습니다.
- 리뷰 태그 중복 매핑 방지를 위해 `(review_id, tag_id)` 조합에 unique constraint를 적용했습니다.
- Swagger 문서화를 위해 각 API에 `@Operation`, `@Parameter`, `@SecurityRequirement(name = "bearerAuth")`를 적용했습니다.

## 📸 스크린 샷 (Optional) 
-

## ✅ 체크리스트
- [x] 불필요한 주석/코드 및 디버깅용 로그 제거
- [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 단위 테스트 등)
- [x] 시뮬레이터 또는 실제 기기에서 정상 동작하는지 확인
- [x] 커밋 메시지 컨벤션을 준수 (*Commit message convention 참고)
- [x] 관련 이슈를 닫는 커밋 메시지 사용 (Closes #)
- [x] PR 제목과 내용 명확히 작성

## 💬 리뷰 포인트 (To Reviewers)
- 한 사용자가 하나의 강의실에 리뷰를 1개만 작성할 수 있도록 제한한 정책이 적절한지 확인 부탁드립니다.
- 리뷰 작성 시 중복 태그 ID가 포함된 요청을 예외 처리하도록 구현했습니다. 이 방식이 적절한지 확인 부탁드립니다.
- 리뷰 삭제 시 `reviewId`, `classroomId`, `userId`를 함께 검증하여 본인 리뷰만 삭제 가능하도록 구현했습니다. 권한 검증 방식이 적절한지 확인 부탁드립니다.
- 리뷰 조회 시 `limit` 기본값을 10으로 설정했습니다. 기본 조회 개수가 적절한지 확인 부탁드립니다.
- `ReviewTag` 삭제 후 `Review`를 삭제하는 방식으로 구현했습니다. 추후 cascade/orphanRemoval 적용 여부를 검토해도 좋을 것 같습니다.