### PR TITLE
feat: 최근 조회한 강의실 목록 API 추가

### DIFF
--- a/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/controller/ClassroomController.java
@@ -7,6 +7,7 @@ import com.dku.emptybear.domain.classroom.dto.response.ClassroomWeeklyScheduleRe
 import com.dku.emptybear.domain.classroom.dto.response.CreateReviewResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomReviewListResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.DeleteReviewResponseDto;
+import com.dku.emptybear.domain.classroom.dto.response.RecentViewedClassroomListResponseDto;
 import com.dku.emptybear.domain.classroom.service.ClassroomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -61,6 +62,20 @@ public class ClassroomController {
                 availabilityStatus,
                 minAvailableTime
         );
+    }
+
+    @Operation(
+            summary = "최근 조회한 강의실 목록 조회",
+            description = "로그인한 사용자가 최근 상세 조회한 강의실 목록을 최신순으로 조회합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/recent-viewed")
+    public RecentViewedClassroomListResponseDto getRecentViewedClassrooms(
+            Authentication authentication
+    ) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return classroomService.getRecentViewedClassrooms(userId);
     }
 
     @Operation(

--- a/src/main/java/com/dku/emptybear/domain/classroom/dto/response/RecentViewedClassroomListResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/dto/response/RecentViewedClassroomListResponseDto.java
@@ -1,0 +1,51 @@
+package com.dku.emptybear.domain.classroom.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class RecentViewedClassroomListResponseDto {
+
+    @Schema(description = "최근 조회한 강의실 목록")
+    private List<RecentViewedClassroomDto> classrooms;
+
+    @Getter
+    @Builder
+    public static class RecentViewedClassroomDto {
+
+        @Schema(description = "강의실 고유 ID", example = "12")
+        private Long classroomId;
+
+        @Schema(description = "건물명", example = "소프트웨어ICT관")
+        private String buildingName;
+
+        @Schema(description = "강의실 호수", example = "516")
+        private String roomName;
+
+        @Schema(description = "층수", example = "5")
+        private Integer floor;
+
+        @Schema(description = "콘센트 여부", example = "true")
+        private Boolean hasOutlet;
+
+        @Schema(description = "로그인 사용자의 즐겨찾기 여부", example = "false")
+        private Boolean isFavorite;
+
+        @Schema(description = "현재 사용 상태 구분값", example = "AVAILABLE_LONG")
+        private String availabilityStatus;
+
+        @Schema(description = "현재 시점 기준 남은 사용 가능 시간(분)", example = "45")
+        private Integer availableMinutes;
+
+        @Schema(description = "다음 강의 시작 시각", example = "15:30", nullable = true)
+        private String nextClassStartTime;
+
+        @Schema(description = "최근 조회 시각", example = "2026-05-29T14:30:00")
+        private LocalDateTime viewedAt;
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/entity/ClassroomViewHistory.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/entity/ClassroomViewHistory.java
@@ -1,0 +1,56 @@
+package com.dku.emptybear.domain.classroom.entity;
+
+import com.dku.emptybear.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "classroom_view_history",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_classroom_view_history_user_classroom",
+                columnNames = {"user_id", "classroom_id"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ClassroomViewHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "classroom_view_history_id")
+    private Long classroomViewHistoryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "classroom_id", nullable = false)
+    private Classroom classroom;
+
+    @Column(name = "viewed_at", nullable = false)
+    private LocalDateTime viewedAt;
+
+    private ClassroomViewHistory(User user, Classroom classroom) {
+        this.user = user;
+        this.classroom = classroom;
+    }
+
+    public static ClassroomViewHistory create(User user, Classroom classroom) {
+        return new ClassroomViewHistory(user, classroom);
+    }
+
+    public void updateViewedAt() {
+        this.viewedAt = LocalDateTime.now();
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.viewedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/repository/ClassroomViewHistoryRepository.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/repository/ClassroomViewHistoryRepository.java
@@ -1,0 +1,29 @@
+package com.dku.emptybear.domain.classroom.repository;
+
+import com.dku.emptybear.domain.classroom.entity.ClassroomViewHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ClassroomViewHistoryRepository extends JpaRepository<ClassroomViewHistory, Long> {
+
+    Optional<ClassroomViewHistory> findByUser_UserIdAndClassroom_ClassroomId(
+            Long userId,
+            Long classroomId
+    );
+
+    @Query("""
+            SELECT cvh
+            FROM ClassroomViewHistory cvh
+            JOIN FETCH cvh.classroom c
+            JOIN FETCH c.building b
+            WHERE cvh.user.userId = :userId
+            ORDER BY cvh.viewedAt DESC
+            """)
+    List<ClassroomViewHistory> findByUserIdWithClassroomAndBuildingOrderByViewedAtDesc(
+            @Param("userId") Long userId
+    );
+}

--- a/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
@@ -7,11 +7,14 @@ import com.dku.emptybear.domain.classroom.dto.response.ClassroomWeeklyScheduleRe
 import com.dku.emptybear.domain.classroom.dto.response.CreateReviewResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.ClassroomReviewListResponseDto;
 import com.dku.emptybear.domain.classroom.dto.response.DeleteReviewResponseDto;
+import com.dku.emptybear.domain.classroom.dto.response.RecentViewedClassroomListResponseDto;
 import com.dku.emptybear.domain.classroom.entity.Classroom;
+import com.dku.emptybear.domain.classroom.entity.ClassroomViewHistory;
 import com.dku.emptybear.domain.classroom.entity.Schedule;
 import com.dku.emptybear.domain.classroom.entity.Review;
 import com.dku.emptybear.domain.classroom.entity.ReviewTag;
 import com.dku.emptybear.domain.classroom.repository.ClassroomRepository;
+import com.dku.emptybear.domain.classroom.repository.ClassroomViewHistoryRepository;
 import com.dku.emptybear.domain.classroom.repository.ReviewRepository;
 import com.dku.emptybear.domain.classroom.repository.ReviewTagRepository;
 import com.dku.emptybear.domain.classroom.repository.ScheduleRepository;
@@ -53,6 +56,7 @@ public class ClassroomService {
     private final ClassroomRepository classroomRepository;
     private final ScheduleRepository scheduleRepository;
     private final FavoriteRepository favoriteRepository;
+    private final ClassroomViewHistoryRepository classroomViewHistoryRepository;
     private final ReviewRepository reviewRepository;
     private final ReviewTagRepository reviewTagRepository;
     private final UserRepository userRepository;
@@ -130,11 +134,74 @@ public class ClassroomService {
     }
 
     /**
+     * 로그인 사용자가 최근 조회한 강의실 목록을 최신순으로 조회한다.
+     */
+    public RecentViewedClassroomListResponseDto getRecentViewedClassrooms(Long userId) {
+        List<ClassroomViewHistory> histories =
+                classroomViewHistoryRepository.findByUserIdWithClassroomAndBuildingOrderByViewedAtDesc(userId);
+
+        List<Long> classroomIds = histories.stream()
+                .map(history -> history.getClassroom().getClassroomId())
+                .toList();
+
+        Set<Long> favoriteClassroomIds = getFavoriteClassroomIds(userId, classroomIds);
+
+        String today = classroomAvailabilityService.getTodayValue();
+        LocalTime now = LocalTime.now();
+
+        List<Schedule> schedules = classroomIds.isEmpty()
+                ? List.of()
+                : scheduleRepository.findByClassroom_ClassroomIdInAndDayOfWeekOrderByStartTimeAsc(
+                        classroomIds,
+                        today
+                );
+
+        Map<Long, List<Schedule>> scheduleMap = schedules.stream()
+                .collect(Collectors.groupingBy(schedule -> schedule.getClassroom().getClassroomId()));
+
+        List<RecentViewedClassroomListResponseDto.RecentViewedClassroomDto> classrooms = histories.stream()
+                .map(history -> {
+                    Classroom classroom = history.getClassroom();
+
+                    List<Schedule> classroomSchedules = scheduleMap.getOrDefault(
+                            classroom.getClassroomId(),
+                            List.of()
+                    );
+
+                    ClassroomAvailability availability = classroomAvailabilityService.calculateAvailability(
+                            classroomSchedules,
+                            now
+                    );
+
+                    return RecentViewedClassroomListResponseDto.RecentViewedClassroomDto.builder()
+                            .classroomId(classroom.getClassroomId())
+                            .buildingName(classroom.getBuilding().getBuildingName())
+                            .roomName(classroom.getRoomName())
+                            .floor(classroom.getFloor())
+                            .hasOutlet(classroom.getHasOutlet())
+                            .isFavorite(favoriteClassroomIds.contains(classroom.getClassroomId()))
+                            .availabilityStatus(availability.getStatus())
+                            .availableMinutes(availability.getAvailableMinutes())
+                            .nextClassStartTime(classroomAvailabilityService.formatTime(availability.getNextClassStartTime()))
+                            .viewedAt(history.getViewedAt())
+                            .build();
+                })
+                .toList();
+
+        return RecentViewedClassroomListResponseDto.builder()
+                .classrooms(classrooms)
+                .build();
+    }
+
+    /**
      * 특정 강의실의 상세 정보, 현재 사용 상태, 즐겨찾기 여부, 리뷰 요약 정보를 조회한다.
      */
+    @Transactional
     public ClassroomDetailResponseDto getClassroomDetail(Long userId, Long classroomId) {
         Classroom classroom = classroomRepository.findByIdWithBuilding(classroomId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의실입니다."));
+
+        recordClassroomView(userId, classroom);
 
         boolean isFavorite = favoriteRepository.existsByUser_UserIdAndClassroom_ClassroomId(
                 userId,
@@ -187,6 +254,23 @@ public class ClassroomService {
                                 .build())
                         .build())
                 .build();
+    }
+
+    /**
+     * 강의실 상세 조회 이력을 생성하거나 최신 조회 시각으로 갱신한다.
+     */
+    private void recordClassroomView(Long userId, Classroom classroom) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        classroomViewHistoryRepository.findByUser_UserIdAndClassroom_ClassroomId(
+                        userId,
+                        classroom.getClassroomId()
+                )
+                .ifPresentOrElse(
+                        ClassroomViewHistory::updateViewedAt,
+                        () -> classroomViewHistoryRepository.save(ClassroomViewHistory.create(user, classroom))
+                );
     }
 
     /**

--- a/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
+++ b/src/main/java/com/dku/emptybear/domain/classroom/service/ClassroomService.java
@@ -263,14 +263,22 @@ public class ClassroomService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-        classroomViewHistoryRepository.findByUser_UserIdAndClassroom_ClassroomId(
-                        userId,
-                        classroom.getClassroomId()
-                )
-                .ifPresentOrElse(
-                        ClassroomViewHistory::updateViewedAt,
-                        () -> classroomViewHistoryRepository.save(ClassroomViewHistory.create(user, classroom))
-                );
+        try {
+            classroomViewHistoryRepository.findByUser_UserIdAndClassroom_ClassroomId(
+                            userId,
+                            classroom.getClassroomId()
+                    )
+                    .ifPresentOrElse(
+                            ClassroomViewHistory::updateViewedAt,
+                            () -> classroomViewHistoryRepository.saveAndFlush(ClassroomViewHistory.create(user, classroom))
+                    );
+        } catch (DataIntegrityViolationException e) {
+            classroomViewHistoryRepository.findByUser_UserIdAndClassroom_ClassroomId(
+                            userId,
+                            classroom.getClassroomId()
+                    )
+                    .ifPresent(ClassroomViewHistory::updateViewedAt);
+        }
     }
 
     /**


### PR DESCRIPTION
## 📝 개요 (Overview)
- 최근 조회한 강의실 목록 조회 API 구현

## 📌 이슈 번호 작성 (Related Issue)
- Closes #25

## 🤔 작업 배경 및 목적 (Why)
-  사용자가 최근에 확인했던 강의실을 다시 빠르게 찾을 수 있도록 최근 조회 이력을 저장하고 조회하는 기능이 필요

## 🏷️ PR 유형 (Type of PR)
- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 🎨 사용자 UI 디자인 변경
- [ ] ♻️ 코드 리팩토링
- [ ] 📝 문서 수정 (Wiki, README 등)
- [ ] ✅ 테스트 추가 및 리팩토링
- [ ] 📁 파일 혹은 폴더 구조 수정 및 삭제

## 🛠️ 주요 변경 사항 (What)
- `ClassroomViewHistory` 엔티티를 추가해 사용자별 강의실 최근 조회 이력을 저장하도록 구현
- 강의실 상세 조회 API 호출 시 최근 조회 이력을 생성하거나 `viewedAt`을 최신 시각으로 갱신하도록 변경
- `GET /api/classrooms/recent-viewed` API를 추가
- 최근 조회 목록 응답에 `classroomId`, `buildingName`, `roomName`, `floor`, `hasOutlet`, `isFavorite`, `availabilityStatus`, `availableMinutes`, `nextClassStartTime`, `viewedAt`을 포함하도록 구현


## 📸 스크린 샷 (Optional) 
-


## ✅ 체크리스트
- [x] 불필요한 주석/코드 및 디버깅용 로그 제거
- [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 단위 테스트 등)
- [x] 시뮬레이터 또는 실제 기기에서 정상 동작하는지 확인
- [x] 커밋 메시지 컨벤션을 준수 (*Commit message convention 참고)
- [x] 관련 이슈를 닫는 커밋 메시지 사용 (Closes #)
- [x] PR 제목과 내용 명확히 작성


## 💬 리뷰 포인트 (To Reviewers)
- 