### PR TITLE
fix: 추천 강의실 응답 필드 추가

### DIFF
--- a/src/main/java/com/dku/emptybear/domain/recommend/dto/response/RecommendClassroomResponseDto.java
+++ b/src/main/java/com/dku/emptybear/domain/recommend/dto/response/RecommendClassroomResponseDto.java
@@ -17,6 +17,9 @@ public class RecommendClassroomResponseDto {
     @Builder
     public static class ClassroomDto {
 
+        @Schema(description = "강의실 고유 ID", example = "12")
+        private Long classroomId;
+
         @Schema(description = "건물명", example = "소프트웨어ICT관")
         private String buildingName;
 
@@ -34,5 +37,11 @@ public class RecommendClassroomResponseDto {
 
         @Schema(description = "콘센트 여부", example = "true")
         private Boolean hasOutlet;
+
+        @Schema(description = "로그인 사용자의 즐겨찾기 여부", example = "false")
+        private Boolean isFavorite;
+
+        @Schema(description = "현재 사용 상태 구분값", example = "AVAILABLE_LONG")
+        private String availabilityStatus;
     }
 }

--- a/src/main/java/com/dku/emptybear/domain/recommend/service/RecommendService.java
+++ b/src/main/java/com/dku/emptybear/domain/recommend/service/RecommendService.java
@@ -112,12 +112,15 @@ public class RecommendService {
 
         RecommendClassroomResponseDto.ClassroomDto response =
                 RecommendClassroomResponseDto.ClassroomDto.builder()
+                        .classroomId(classroom.getClassroomId())
                         .buildingName(classroom.getBuilding().getBuildingName())
                         .classroomName(classroom.getRoomName())
                         .availableHour(toAvailableHour(availability.availableMinutes()))
                         .availableMinute(toAvailableMinute(availability.availableMinutes()))
                         .nextClassTime(formatTime(availability))
                         .hasOutlet(classroom.getHasOutlet())
+                        .isFavorite(favorite)
+                        .availabilityStatus(availability.availabilityStatus())
                         .build();
 
         return Optional.of(new RecommendCandidate(response, score));


### PR DESCRIPTION
## 📝 개요 (Overview)
- 최근 조회한 강의실 목록 API를 추가하고, 추천 강의실 목록 API 응답 필드를 보완

## 📌 이슈 번호 작성 (Related Issue)
- Closes #27 

## 🤔 작업 배경 및 목적 (Why)
- 사용자가 최근 조회한 강의실을 다시 확인할 수 있도록 최근 조회 이력을 저장하고 목록으로 조회하는 API 필요
- 프론트엔드 추천 결과 카드에서 상세보기, 즐겨찾기 상태, 사용 가능 상태 뱃지를 표시하기 위해 추천 강의실 목록 API 응답에 추가 필드가 필요

## 🏷️ PR 유형 (Type of PR)
- [ ] ✨ 새로운 기능 추가
- [x] 🐛 버그 수정
- [ ] 🎨 사용자 UI 디자인 변경
- [ ] ♻️ 코드 리팩토링
- [ ] 📝 문서 수정 (Wiki, README 등)
- [ ] ✅ 테스트 추가 및 리팩토링
- [ ] 📁 파일 혹은 폴더 구조 수정 및 삭제

## 🛠️ 주요 변경 사항 (What)
- 최근 조회 강의실 목록 응답에 강의실 정보, 즐겨찾기 여부, 사용 가능 상태, 조회 시각을 포함했습니다.
- 추천 강의실 목록 API 응답에 `classroomId`, `isFavorite`, `availabilityStatus`를 추가했습니다.

## 📸 스크린 샷 (Optional) 
-


## ✅ 체크리스트
- [x] 불필요한 주석/코드 및 디버깅용 로그 제거
- [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 단위 테스트 등)
- [x] 시뮬레이터 또는 실제 기기에서 정상 동작하는지 확인
- [x] 커밋 메시지 컨벤션을 준수 (*Commit message convention 참고)
- [x] 관련 이슈를 닫는 커밋 메시지 사용 (Closes #)
- [x] PR 제목과 내용 명확히 작성


## 💬 리뷰 포인트 (To Reviewers)
-
